### PR TITLE
OPENEUROPA-378: Remove lengthy default comments in overridden Twig templates.

### DIFF
--- a/templates/blocks/block--bare.html.twig
+++ b/templates/blocks/block--bare.html.twig
@@ -1,17 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation for a branding block.
+ * Theme override system branding block.
  *
- * Each branding element variable (logo, name, slogan) is only available if
- * enabled in the block configuration.
- *
- * Available variables:
- * - site_logo: Logo for site as defined in Appearance or theme settings.
- * - site_name: Name for site as defined in Site information settings.
- * - site_slogan: Slogan for site as defined in Site information settings.
- *
- * @ingroup themeable
+ * @see ./core/modules/system/templates/block--system-branding-block.html.twig
  */
 #}
 {{ content }}

--- a/templates/blocks/block--bare.html.twig
+++ b/templates/blocks/block--bare.html.twig
@@ -3,7 +3,7 @@
  * @file
  * Theme override system branding block.
  *
- * @see ./core/modules/system/templates/block--system-branding-block.html.twig
+ * @see ./core/modules/system/templates/block.html.twig
  */
 #}
 {{ content }}

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -3,15 +3,7 @@
  * @file
  * Default theme implementation for a branding block.
  *
- * Each branding element variable (logo, name, slogan) is only available if
- * enabled in the block configuration.
- *
- * Available variables:
- * - site_logo: Logo for site as defined in Appearance or theme settings.
- * - site_name: Name for site as defined in Site information settings.
- * - site_slogan: Slogan for site as defined in Site information settings.
- *
- * @ingroup themeable
+ * @see ./core/modules/system/templates/block--system-branding-block.html.twig
  */
 #}
 {% block content %}

--- a/templates/blocks/block--system-branding-block.html.twig
+++ b/templates/blocks/block--system-branding-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for a branding block.
+ * Theme override for the branding block.
  *
  * @see ./core/modules/system/templates/block--system-branding-block.html.twig
  */

--- a/templates/blocks/block--system-breadcrumb-block.html.twig
+++ b/templates/blocks/block--system-breadcrumb-block.html.twig
@@ -3,30 +3,8 @@
  * @file
  * Overrides theme implementation for breadcrumb block wrapper.
  *
- * Available variables:
- * - plugin_id: The ID of the block implementation.
- * - label: The configured label of the block if visible.
- * - configuration: A list of the block's configuration values.
- *   - label: The configured label for the block.
- *   - label_display: The display settings for the label.
- *   - provider: The module or other provider that provided this block plugin.
- *   - Block plugin specific settings will also be stored here.
- * - content: The content of this block.
- * - attributes: array of HTML attributes populated by modules, intended to
- *   be added to the main container tag of this template.
- *   - id: A valid HTML ID and guaranteed unique.
- * - title_attributes: Same as attributes, except applied to the main title
- *   tag that appears in the template.
- * - content_attributes: Same as attributes, except applied to the main content
- *   tag that appears in the template.
- * - title_prefix: Additional output populated by modules, intended to be
- *   displayed in front of the main title tag that appears in the template.
- * - title_suffix: Additional output populated by modules, intended to be
- *   displayed after the main title tag that appears in the template.
+ * @see ./core/themes/stable/templates/block/block.html.twig
  *
- * @see template_preprocess_block()
- *
- * @ingroup themeable
  */
 #}
 {% include '@oe_theme/blocks/block--bare.html.twig' %}

--- a/templates/blocks/block--system-breadcrumb-block.html.twig
+++ b/templates/blocks/block--system-breadcrumb-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Overrides theme implementation for breadcrumb block wrapper.
+ * Theme override for the breadcrumb block wrapper.
  *
  * @see ./core/themes/stable/templates/block/block.html.twig
  *

--- a/templates/blocks/block--system-menu-block--main.html.twig
+++ b/templates/blocks/block--system-menu-block--main.html.twig
@@ -3,32 +3,7 @@
  * @file
  * Theme override for a menu block.
  *
- * Available variables:
- * - plugin_id: The ID of the block implementation.
- * - label: The configured label of the block if visible.
- * - configuration: A list of the block's configuration values.
- *   - label: The configured label for the block.
- *   - label_display: The display settings for the label.
- *   - provider: The module or other provider that provided this block plugin.
- *   - Block plugin specific settings will also be stored here.
- * - content: The content of this block.
- * - attributes: HTML attributes for the containing element.
- *   - id: A valid HTML ID and guaranteed unique.
- * - title_attributes: HTML attributes for the title element.
- * - content_attributes: HTML attributes for the content element.
- * - title_prefix: Additional output populated by modules, intended to be
- *   displayed in front of the main title tag that appears in the template.
- * - title_suffix: Additional output populated by modules, intended to be
- *   displayed after the main title tag that appears in the template.
- *
- * Headings should be used on navigation menus that consistently appear on
- * multiple pages. When this menu block's label is configured to not be
- * displayed, it is automatically made invisible using the 'visually-hidden' CSS
- * class, which still keeps it visible for screen-readers and assistive
- * technology. Headings allow screen-reader and keyboard only users to navigate
- * to or skip the links.
- * See http://juicystudio.com/article/screen-readers-display-none.php and
- * http://www.w3.org/TR/WCAG-TECHS/H42.html for more information.
+ * @see block--bare.html.twig
  */
 #}
 {% include '@oe_theme/blocks/block--bare.html.twig' %}

--- a/templates/blocks/block--system-menu-block--main.html.twig
+++ b/templates/blocks/block--system-menu-block--main.html.twig
@@ -1,9 +1,9 @@
 {#
 /**
  * @file
- * Theme override for a menu block.
+ * Theme override for the menu block.
  *
- * @see block--bare.html.twig
+ * @see ./core/modules/system/templates/block.html.twig
  */
 #}
 {% include '@oe_theme/blocks/block--bare.html.twig' %}

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -3,71 +3,7 @@
  * @file
  * Theme override to display a node.
  *
- * Available variables:
- * - node: The node entity with limited access to object properties and methods.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - node.getCreatedTime() will return the node creation timestamp.
- *   - node.hasField('field_example') returns TRUE if the node bundle includes
- *     field_example. (This does not indicate the presence of a value in this
- *     field.)
- *   - node.isPublished() will return whether the node is published or not.
- *   Calling other methods, such as node.delete(), will result in an exception.
- *   See \Drupal\node\Entity\Node for a full list of public properties and
- *   methods for the node object.
- * - label: The title of the node.
- * - content: All node items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - author_picture: The node author user entity, rendered using the "compact"
- *   view mode.
- * - metadata: Metadata for this node.
- * - date: Themed creation date field.
- * - author_name: Themed author name field.
- * - url: Direct URL of the current node.
- * - display_submitted: Whether submission information should be displayed.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - node: The current template type (also known as a "theming hook").
- *   - node--type-[type]: The current node type. For example, if the node is an
- *     "Article" it would result in "node--type-article". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - node--view-mode-[view_mode]: The View Mode of the node; for example, a
- *     teaser would result in: "node--view-mode-teaser", and
- *     full: "node--view-mode-full".
- *   The following are controlled through the node publishing options.
- *   - node--promoted: Appears on nodes promoted to the front page.
- *   - node--sticky: Appears on nodes ordered above other non-sticky nodes in
- *     teaser listings.
- *   - node--unpublished: Appears on unpublished nodes visible only to site
- *     admins.
- * - title_attributes: Same as attributes, except applied to the main title
- *   tag that appears in the template.
- * - content_attributes: Same as attributes, except applied to the main
- *   content tag that appears in the template.
- * - author_attributes: Same as attributes, except applied to the author of
- *   the node tag that appears in the template.
- * - title_prefix: Additional output populated by modules, intended to be
- *   displayed in front of the main title tag that appears in the template.
- * - title_suffix: Additional output populated by modules, intended to be
- *   displayed after the main title tag that appears in the template.
- * - view_mode: View mode; for example, "teaser" or "full".
- * - teaser: Flag for the teaser state. Will be true if view_mode is 'teaser'.
- * - page: Flag for the full page state. Will be true if view_mode is 'full'.
- * - readmore: Flag for more state. Will be true if the teaser content of the
- *   node cannot hold the main body content.
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_node()
- *
- * @todo Remove the id attribute (or make it a class), because if that gets
- *   rendered twice on a page this is invalid CSS for example: two lists
- *   in different view modes.
+ * @see ./core/themes/stable/templates/content/node.html.twig
  */
 #}
 {% extends "@stable/content/node.html.twig" %}

--- a/templates/field/field--bare.html.twig
+++ b/templates/field/field--bare.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Bare field template, it just prints out the field content.
+ * Theme override for the bare field template.
  *
  * @see ./core/themes/stable/templates/field/field.html.twig
  */

--- a/templates/field/field--bare.html.twig
+++ b/templates/field/field--bare.html.twig
@@ -3,37 +3,7 @@
  * @file
  * Bare field template, it just prints out the field content.
  *
- * To override output, copy the "field.html.twig" from the templates directory
- * to your theme's directory and customize it, just like customizing other
- * Drupal templates such as page.html.twig or node.html.twig.
- *
- * Instead of overriding the theming for all fields, you can also just override
- * theming for a subset of fields using
- * @link themeable Theme hook suggestions. @endlink For example,
- * here are some theme hook suggestions that can be used for a field_foo field
- * on an article node type:
- * - field--node--field-foo--article.html.twig
- * - field--node--field-foo.html.twig
- * - field--node--article.html.twig
- * - field--field-foo.html.twig
- * - field--text-with-summary.html.twig
- * - field.html.twig
- *
- * Available variables:
- * - attributes: HTML attributes for the containing element.
- * - label_hidden: Whether to show the field label or not.
- * - title_attributes: HTML attributes for the title.
- * - label: The label for the field.
- * - multiple: TRUE if a field can contain multiple items.
- * - items: List of all the field items. Each item contains:
- *   - attributes: List of HTML attributes for each item.
- *   - content: The field item's content.
- * - entity_type: The entity type to which the field belongs.
- * - field_name: The name of the field.
- * - field_type: The type of the field.
- * - label_display: The display settings for the label.
- *
- * @see template_preprocess_field()
+ * @see ./core/themes/stable/templates/field/field.html.twig
  */
 #}
 {% for item in items %}

--- a/templates/form/container.html.twig
+++ b/templates/form/container.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override of a container used to wrap child elements accordingly to the ECL library.
+ * Theme override for a container used to wrap child elements accordingly to the ECL library.
  *
  * @see ./core/themes/stable/templates/form/container.html.twig
  */

--- a/templates/form/container.html.twig
+++ b/templates/form/container.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a container used to wrap child elements accordingly to the ECL library.
+ * Theme override for a container used to wrap child elements.
  *
  * @see ./core/themes/stable/templates/form/container.html.twig
  */

--- a/templates/form/container.html.twig
+++ b/templates/form/container.html.twig
@@ -1,22 +1,9 @@
 {#
 /**
  * @file
- * Theme override of a container used to wrap child elements.
+ * Theme override of a container used to wrap child elements accordingly to the ECL library.
  *
- * Used for grouped form items. Can also be used as a theme wrapper for any
- * renderable element, to surround it with a <div> and HTML attributes.
- * See \Drupal\Core\Render\Element\RenderElement for more
- * information on the #theme_wrappers render array property, and
- * \Drupal\Core\Render\Element\container for usage of the container render
- * element.
- *
- * Available variables:
- * - attributes: HTML attributes for the containing element.
- * - children: The rendered child elements of the container.
- * - has_parent: A flag to indicate that the container has one or more parent
-     containers.
- *
- * @see template_preprocess_container()
+ * @see ./core/themes/stable/templates/form/container.html.twig
  */
 #}
 {%

--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a fieldset element and its children accordingly to the ECL library.
+ * Theme override for a fieldset element and its children.
  *
  * @see ./core/themes/stable/templates/form/fieldset.html.twig
  */

--- a/templates/form/fieldset.html.twig
+++ b/templates/form/fieldset.html.twig
@@ -1,23 +1,9 @@
 {#
 /**
  * @file
- * Theme override for a fieldset element and its children.
+ * Theme override for a fieldset element and its children accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: HTML attributes for the fieldset element.
- * - errors: (optional) Any errors for this fieldset element, may not be set.
- * - required: Boolean indicating whether the fieldeset element is required.
- * - legend: The legend element containing the following properties:
- *   - title: Title of the fieldset, intended for use as the text of the legend.
- *   - attributes: HTML attributes to apply to the legend.
- * - description: The description element containing the following properties:
- *   - content: The description content of the fieldset.
- *   - attributes: HTML attributes to apply to the description container.
- * - children: The rendered child elements of the fieldset.
- * - prefix: The content to add before the fieldset children.
- * - suffix: The content to add after the fieldset children.
- *
- * @see template_preprocess_fieldset()
+ * @see ./core/themes/stable/templates/form/fieldset.html.twig
  */
 #}
 {%

--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -1,15 +1,9 @@
 {#
 /**
  * @file
- * Theme override for a form element label.
+ * Theme override for a form element label accordingly to the ECL library.
  *
- * Available variables:
- * - title: The label's text.
- * - title_display: Elements title_display setting.
- * - required: An indicator for whether the associated form element is required.
- * - attributes: A list of HTML attributes for the label.
- *
- * @see template_preprocess_form_element_label()
+ * @see ./core/themes/stable/templates/form/form-element.html.twig
  */
 #}
 {%

--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -3,7 +3,7 @@
  * @file
  * Theme override for a form element label accordingly to the ECL library.
  *
- * @see ./core/themes/stable/templates/form/form-element.html.twig
+ * @see ./core/themes/stable/templates/form/form-element-label.html.twig
  */
 #}
 {%

--- a/templates/form/form-element-label.html.twig
+++ b/templates/form/form-element-label.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a form element label accordingly to the ECL library.
+ * Theme override for a form element label.
  *
  * @see ./core/themes/stable/templates/form/form-element-label.html.twig
  */

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a form element accordingly to the ECL library.
+ * Theme override for a form element.
  *
  * @see ./core/themes/stable/templates/form/form-element.html.twig
  */

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -1,47 +1,9 @@
 {#
 /**
  * @file
- * Theme override for a form element.
+ * Theme override for a form element accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: HTML attributes for the containing element.
- * - errors: (optional) Any errors for this form element, may not be set.
- * - prefix: (optional) The form element prefix, may not be set.
- * - suffix: (optional) The form element suffix, may not be set.
- * - required: The required marker, or empty if the associated form element is
- *   not required.
- * - type: The type of the element.
- * - name: The name of the element.
- * - label: A rendered label element.
- * - label_display: Label display setting. It can have these values:
- *   - before: The label is output before the element. This is the default.
- *     The label includes the #title and the required marker, if #required.
- *   - after: The label is output after the element. For example, this is used
- *     for radio and checkbox #type elements. If the #title is empty but the
- *     field is #required, the label will contain only the required marker.
- *   - invisible: Labels are critical for screen readers to enable them to
- *     properly navigate through forms but can be visually distracting. This
- *     property hides the label for everyone except screen readers.
- *   - attribute: Set the title attribute on the element to create a tooltip but
- *     output no label element. This is supported only for checkboxes and radios
- *     in \Drupal\Core\Render\Element\CompositeFormElementTrait::preRenderCompositeFormElement().
- *     It is used where a visual label is not needed, such as a table of
- *     checkboxes where the row and column provide the context. The tooltip will
- *     include the title and required marker.
- * - description: (optional) A list of description properties containing:
- *    - content: A description of the form element, may not be set.
- *    - attributes: (optional) A list of HTML attributes to apply to the
- *      description content wrapper. Will only be set when description is set.
- * - description_display: Description display setting. It can have these values:
- *   - before: The description is output before the element.
- *   - after: The description is output after the element. This is the default
- *     value.
- *   - invisible: The description is output after the element, hidden visually
- *     but available to screen readers.
- * - disabled: True if the element is disabled.
- * - title_display: Title display setting.
- *
- * @see template_preprocess_form_element()
+ * @see ./core/themes/stable/templates/form/form-element.html.twig
  */
 #}
 {%

--- a/templates/form/form.html.twig
+++ b/templates/form/form.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a 'form' element accordingly to the ECL library.
+ * Theme override for a 'form' element.
  *
  * @see ./core/themes/stable/templates/form/form.html.twig
  */

--- a/templates/form/form.html.twig
+++ b/templates/form/form.html.twig
@@ -1,13 +1,9 @@
 {#
 /**
  * @file
- * Theme override for a 'form' element.
+ * Theme override for a 'form' element accordingly to the ECL library.
  *
- * Available variables
- * - attributes: A list of HTML attributes for the wrapper element.
- * - children: The child elements of the form.
- *
- * @see template_preprocess_form()
+ * @see ./core/themes/stable/templates/form/form.html.twig
  */
 #}
 <form{{ attributes.addClass('ecl-form') }}>

--- a/templates/form/input--checkbox.html.twig
+++ b/templates/form/input--checkbox.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
  * Available variables:
  * - attributes: A list of HTML attributes for the input element.
@@ -10,7 +10,7 @@
  * - has_error: Optional (boolean): has error (optional, default: false).
  * - has_extra: Optional (string): extra CSS classes (optional, default: '').
  *
- * @see template_preprocess_input()
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 

--- a/templates/form/input--checkbox.html.twig
+++ b/templates/form/input--checkbox.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * Available variables:
  * - attributes: A list of HTML attributes for the input element.

--- a/templates/form/input--email.html.twig
+++ b/templates/form/input--email.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * @see ./core/themes/stable/templates/form/input.html.twig
  */

--- a/templates/form/input--email.html.twig
+++ b/templates/form/input--email.html.twig
@@ -1,13 +1,9 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: A list of HTML attributes for the input element.
- * - children: Optional additional rendered elements.
- *
- * @see template_preprocess_input()
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 {%

--- a/templates/form/input--password.html.twig
+++ b/templates/form/input--password.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * @see ./core/themes/stable/templates/form/input.html.twig
  */

--- a/templates/form/input--password.html.twig
+++ b/templates/form/input--password.html.twig
@@ -1,13 +1,9 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: A list of HTML attributes for the input element.
- * - children: Optional additional rendered elements.
- *
- * @see template_preprocess_input()
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 {%

--- a/templates/form/input--radio.html.twig
+++ b/templates/form/input--radio.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
  * Available variables:
  * - attributes: A list of HTML attributes for the input element.
@@ -10,7 +10,7 @@
  * - has_error: Optional (boolean): has error (optional, default: false).
  * - has_extra: Optional (string): extra CSS classes (optional, default: '').
  *
- * @see template_preprocess_input()
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 {% include '@ecl/ecl-forms-radios' with {

--- a/templates/form/input--radio.html.twig
+++ b/templates/form/input--radio.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * Available variables:
  * - attributes: A list of HTML attributes for the input element.

--- a/templates/form/input--submit.html.twig
+++ b/templates/form/input--submit.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * @see ./core/themes/stable/templates/form/input.html.twig
  */

--- a/templates/form/input--submit.html.twig
+++ b/templates/form/input--submit.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
  * @see ./core/themes/stable/templates/form/input.html.twig
  */

--- a/templates/form/input--submit.html.twig
+++ b/templates/form/input--submit.html.twig
@@ -1,15 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation for an 'input' #type form element.
+ * Default theme implementation for an 'input' #type form element accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: A list of HTML attributes for the input element.
- * - children: Optional additional rendered elements.
- *
- * @see template_preprocess_input()
- *
- * @ingroup themeable
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 {% set extraAttributes = [] %}

--- a/templates/form/input--textfield.html.twig
+++ b/templates/form/input--textfield.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element accordingly to the ECL library.
+ * Theme override for an 'input' #type form element.
  *
  * @see ./core/themes/stable/templates/form/input.html.twig
  */

--- a/templates/form/input--textfield.html.twig
+++ b/templates/form/input--textfield.html.twig
@@ -1,13 +1,9 @@
 {#
 /**
  * @file
- * Theme override for an 'input' #type form element.
+ * Theme override for an 'input' #type form element accordingly to the ECL library.
  *
- * Available variables:
- * - attributes: A list of HTML attributes for the input element.
- * - children: Optional additional rendered elements.
- *
- * @see template_preprocess_input()
+ * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
 {%

--- a/templates/form/radios.html.twig
+++ b/templates/form/radios.html.twig
@@ -3,11 +3,7 @@
  * @file
  * Theme override for a 'radios' #type form element.
  *
- * Available variables
- * - attributes: A list of HTML attributes for the wrapper element.
- * - children: The rendered radios.
- *
- * @see template_preprocess_radios()
+ * @see ./core/themes/stable/templates/form/radios.html.twig
  */
 #}
 <div{{ attributes.setAttribute("role", "radiogroup") }}>{{ children }}</div>

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a select element.
+ * Theme override for a 'select' #type element.
  *
  * @see ./core/themes/stable/templates/form/select.html.twig
  */

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -3,11 +3,7 @@
  * @file
  * Theme override for a select element.
  *
- * Available variables:
- * - attributes: HTML attributes for the select tag.
- * - options: The option element children.
- *
- * @see template_preprocess_select()
+ * @see ./core/themes/stable/templates/form/select.html.twig
  */
 #}
 {% set extra_attributes = ['ecl-select'] %}

--- a/templates/form/textarea.html.twig
+++ b/templates/form/textarea.html.twig
@@ -3,14 +3,7 @@
  * @file
  * Theme override for a 'textarea' #type form element.
  *
- * Available variables
- * - wrapper_attributes: A list of HTML attributes for the wrapper element.
- * - attributes: A list of HTML attributes for the textarea element.
- * - resizable: An indicator for whether the textarea is resizable.
- * - required: An indicator for whether the textarea is required.
- * - value: The textarea content.
- *
- * @see template_preprocess_textarea()
+ * @see ./core/themes/stable/templates/form/textarea.html.twig
  */
 #}
 

--- a/templates/html/html.html.twig
+++ b/templates/html/html.html.twig
@@ -3,26 +3,7 @@
  * @file
  * Default theme implementation for the basic structure of a single Drupal page.
  *
- * Variables:
- * - logged_in: A flag indicating if user is logged in.
- * - root_path: The root path of the current page (e.g., node, admin, user).
- * - node_type: The content type for the current node, if the page is a node.
- * - head_title: List of text elements that make up the head_title variable.
- *   May contain one or more of the following:
- *   - title: The title of the page.
- *   - name: The name of the site.
- *   - slogan: The slogan of the site.
- * - page_top: Initial rendered markup. This should be printed before 'page'.
- * - page: The rendered page markup.
- * - page_bottom: Closing rendered markup. This variable should be printed after
- *   'page'.
- * - db_offline: A flag indicating if the database is offline.
- * - placeholder_token: The token for generating head, css, js and js-bottom
- *   placeholders.
- *
- * @see template_preprocess_html()
- *
- * @ingroup themeable
+ * @see ./core/themes/stable/templates/layout/html.html.twig
  */
 #}
 <!DOCTYPE html>

--- a/templates/html/html.html.twig
+++ b/templates/html/html.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for the basic structure of a single Drupal page.
+ * Theme override for the basic structure of a single Drupal page.
  *
  * @see ./core/themes/stable/templates/layout/html.html.twig
  */

--- a/templates/layout/page.html.twig
+++ b/templates/layout/page.html.twig
@@ -3,41 +3,7 @@
  * @file
  * Theme override to display a single page.
  *
- * The doctype, html, head and body tags are not in this template. Instead they
- * can be found in the html.html.twig template in this directory.
- *
- * Available variables:
- *
- * General utility variables:
- * - base_path: The base URL path of the Drupal installation. Will usually be
- *   "/" unless you have installed Drupal in a sub-directory.
- * - is_front: A flag indicating if the current page is the front page.
- * - logged_in: A flag indicating if the user is registered and signed in.
- * - is_admin: A flag indicating if the user has permission to access
- *   administration pages.
- *
- * Site identity:
- * - front_page: The URL of the front page. Use this instead of base_path when
- *   linking to the front page. This includes the language domain or prefix.
- *
- * Page content (in order of occurrence in the default page.html.twig):
- * - messages: Status and error messages. Should be displayed prominently.
- * - node: Fully loaded node, if there is an automatically-loaded node
- *   associated with the page and the node ID is the second argument in the
- *   page's path (e.g. node/12345 and node/12345/revisions, but not
- *   comment/reply/12345).
- *
- * Regions:
- * - page.site_top_bar: Contains items site top bar items, such as: site switchers, user account menu, etc.
- * - page.site_header: Contains header items, such as: language switcher, search box, etc.
- * - page.breadcrumb: Contains the breadcrumb block.
- * - page.page_header: Contains meta information about the current page.
- * - page.navigation: Contains main navigation menu.
- * - page.content: The main content of the current page.
- * - page.footer: Items for the footer region.
- *
- * @see template_preprocess_page()
- * @see html.html.twig
+ * @see ./core/themes/stable/templates/layout/page.html.twig
  */
 #}
 

--- a/templates/layout/region--breadcrumb.html.twig
+++ b/templates/layout/region--breadcrumb.html.twig
@@ -3,13 +3,7 @@
  * @file
  * Theme override to display a region.
  *
- * Available variables:
- * - content: The content for this region, typically blocks.
- * - attributes: HTML attributes for the region div.
- * - region: The name of the region variable as defined in the theme's
- *   .info.yml file.
- *
- * @see template_preprocess_region()
+ * @see ./core/themes/stable/templates/layout/region.html.twig
  */
 #}
 {% if content %}

--- a/templates/layout/region--navigation.html.twig
+++ b/templates/layout/region--navigation.html.twig
@@ -3,13 +3,7 @@
  * @file
  * Theme override to display a region.
  *
- * Available variables:
- * - content: The content for this region, typically blocks.
- * - attributes: HTML attributes for the region div.
- * - region: The name of the region variable as defined in the theme's
- *   .info.yml file.
- *
- * @see template_preprocess_region()
+ * @see ./core/themes/stable/templates/layout/region.html.twig
  */
 #}
 {% if content %}

--- a/templates/layout/region--site-header.html.twig
+++ b/templates/layout/region--site-header.html.twig
@@ -3,13 +3,7 @@
  * @file
  * Theme override to display a region.
  *
- * Available variables:
- * - content: The content for this region, typically blocks.
- * - attributes: HTML attributes for the region div.
- * - region: The name of the region variable as defined in the theme's
- *   .info.yml file.
- *
- * @see template_preprocess_region()
+ * @see ./core/themes/stable/templates/layout/region.html.twig
  */
 #}
 {% if content %}

--- a/templates/layout/region--site-top-bar.html.twig
+++ b/templates/layout/region--site-top-bar.html.twig
@@ -3,13 +3,7 @@
  * @file
  * Theme override to display a region.
  *
- * Available variables:
- * - content: The content for this region, typically blocks.
- * - attributes: HTML attributes for the region div.
- * - region: The name of the region variable as defined in the theme's
- *   .info.yml file.
- *
- * @see template_preprocess_region()
+ * @see ./core/themes/stable/templates/layout/region.html.twig
  */
 #}
 {% if content %}

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a breadcrumb trail.
+ * Theme override for a breadcrumb trail accordingly to the ECL library.
  *
  * Available variables:
  * - breadcrumb: Breadcrumb trail items.

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for the breadcrumb trail accordingly to the ECL library.
+ * Theme override for the breadcrumb trail.
  *
  * Available variables:
  * - breadcrumb: Breadcrumb trail items.

--- a/templates/navigation/breadcrumb.html.twig
+++ b/templates/navigation/breadcrumb.html.twig
@@ -1,11 +1,13 @@
 {#
 /**
  * @file
- * Theme override for a breadcrumb trail accordingly to the ECL library.
+ * Theme override for the breadcrumb trail accordingly to the ECL library.
  *
  * Available variables:
  * - breadcrumb: Breadcrumb trail items.
  * - segments: ECL-compatible breadcrumb trail items.
+ *
+ * @see ./core/themes/stable/templates/navigation/breadcrumb.html.twig
  */
 #}
 {% if segments %}

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a menu accordingly to the ECL library.
+ * Theme override to display a menu.
  *
  * @see ./core/themes/stable/templates/navigation/menu.html.twig
  */

--- a/templates/navigation/menu--main.html.twig
+++ b/templates/navigation/menu--main.html.twig
@@ -1,21 +1,9 @@
 {#
 /**
  * @file
- * Theme override to display a menu.
+ * Theme override to display a menu accordingly to the ECL library.
  *
- * Available variables:
- * - menu_name: The machine name of the menu.
- * - items: A nested list of menu items. Each menu item contains:
- *   - attributes: HTML attributes for the menu item.
- *   - below: The menu item child items.
- *   - title: The menu link title.
- *   - url: The menu link url, instance of \Drupal\Core\Url
- *   - localized_options: Menu link localized options.
- *   - is_expanded: TRUE if the link has visible children within the current
- *     menu tree.
- *   - is_collapsed: TRUE if the link has children within the current menu tree
- *     that are not currently visible.
- *   - in_active_trail: TRUE if the link is in the active trail.
+ * @see ./core/themes/stable/templates/navigation/menu.html.twig
  */
 #}
 {{ attach_library('oe_theme/navigation') }}

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -1,14 +1,9 @@
 {#
 /**
  * @file
- * Theme override to display primary and secondary local tasks.
+ * Theme override to display primary and secondary local tasks accordingly to the ECL library.
  *
- * Available variables:
- * - primary: HTML list items representing primary tasks.
- * - secondary: HTML list items representing primary tasks.
- *
- * Each item in these variables (primary and secondary) can be individually
- * themed in menu-local-task.html.twig.
+ * @see ./core/themes/stable/templates/navigation/menu-local-tasks.html.twig
  */
 #}
 {% if primary %}

--- a/templates/navigation/menu-local-tasks.html.twig
+++ b/templates/navigation/menu-local-tasks.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display primary and secondary local tasks accordingly to the ECL library.
+ * Theme override to display primary and secondary local tasks.
  *
  * @see ./core/themes/stable/templates/navigation/menu-local-tasks.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-accordion.html.twig
+++ b/templates/paragraphs/paragraph--oe-accordion.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Overrides theme implementation to display a paragraph accordingly to the ECL library.
+ * Theme override to display the 'accordion' #type paragraph accordingly to the ECL library.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-accordion.html.twig
+++ b/templates/paragraphs/paragraph--oe-accordion.html.twig
@@ -1,41 +1,9 @@
 {#
 /**
  * @file
- * Overrides theme implementation to display a paragraph.
+ * Overrides theme implementation to display a paragraph accordingly to the ECL library.
  *
- * Available variables:
- * - paragraph: Full paragraph entity.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
- *   - paragraph.id(): The paragraph ID.
- *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
- *   - paragraph.getOwnerId(): The user ID of the paragraph author.
- *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
- *   and methods for the paragraph object.
- * - content: All paragraph items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - paragraphs: The current template type (also known as a "theming hook").
- *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
- *     "Image" it would result in "paragraphs--type--image". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
- *     preview would result in: "paragraphs--view-mode--preview", and
- *     default: "paragraphs--view-mode--default".
- * - view_mode: View mode; for example, "preview" or "full".
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_paragraph()
- *
- * @ingroup themeable
+ * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
 {{ attach_library('oe_theme/accordions') }}

--- a/templates/paragraphs/paragraph--oe-accordion.html.twig
+++ b/templates/paragraphs/paragraph--oe-accordion.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display the 'accordion' #type paragraph accordingly to the ECL library.
+ * Theme override to display the 'accordion' #type paragraph.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-links-block.html.twig
+++ b/templates/paragraphs/paragraph--oe-links-block.html.twig
@@ -1,41 +1,9 @@
 {#
 /**
  * @file
- * Overrides theme implementation to display a paragraph.
+ * Overrides theme implementation to display a paragraph accordingly to the ECL library.
  *
- * Available variables:
- * - paragraph: Full paragraph entity.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
- *   - paragraph.id(): The paragraph ID.
- *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
- *   - paragraph.getOwnerId(): The user ID of the paragraph author.
- *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
- *   and methods for the paragraph object.
- * - content: All paragraph items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - paragraphs: The current template type (also known as a "theming hook").
- *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
- *     "Image" it would result in "paragraphs--type--image". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
- *     preview would result in: "paragraphs--view-mode--preview", and
- *     default: "paragraphs--view-mode--default".
- * - view_mode: View mode; for example, "preview" or "full".
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_paragraph()
- *
- * @ingroup themeable
+ * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
 {% include '@ecl/ecl-link-blocks' with {

--- a/templates/paragraphs/paragraph--oe-links-block.html.twig
+++ b/templates/paragraphs/paragraph--oe-links-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Overrides theme implementation to display a paragraph accordingly to the ECL library.
+ * Theme override to display the 'links block' #type paragraph accordingly to the ECL library.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-links-block.html.twig
+++ b/templates/paragraphs/paragraph--oe-links-block.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display the 'links block' #type paragraph accordingly to the ECL library.
+ * Theme override to display the 'links block' #type paragraph.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-quote.html.twig
+++ b/templates/paragraphs/paragraph--oe-quote.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph accordingly to the ECL library.
+ * Theme override to display the 'quote' #type paragraph accordingly to the ECL library.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-quote.html.twig
+++ b/templates/paragraphs/paragraph--oe-quote.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display the 'quote' #type paragraph accordingly to the ECL library.
+ * Theme override to display the 'quote' #type paragraph.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph--oe-quote.html.twig
+++ b/templates/paragraphs/paragraph--oe-quote.html.twig
@@ -1,41 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a paragraph accordingly to the ECL library.
  *
- * Available variables:
- * - paragraph: Full paragraph entity.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
- *   - paragraph.id(): The paragraph ID.
- *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
- *   - paragraph.getOwnerId(): The user ID of the paragraph author.
- *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
- *   and methods for the paragraph object.
- * - content: All paragraph items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - paragraphs: The current template type (also known as a "theming hook").
- *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
- *     "Image" it would result in "paragraphs--type--image". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
- *     preview would result in: "paragraphs--view-mode--preview", and
- *     default: "paragraphs--view-mode--default".
- * - view_mode: View mode; for example, "preview" or "full".
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_paragraph()
- *
- * @ingroup themeable
+ * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
 {# @todo Include ECL template as soon as this is fixed: https://webgate.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-340 #}

--- a/templates/paragraphs/paragraph.html.twig
+++ b/templates/paragraphs/paragraph.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override to display a paragraph #type accordingly to the ECL library.
+ * Theme override to display a paragraph #type.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph.html.twig
+++ b/templates/paragraphs/paragraph.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph accordingly to the ECL library.
+ * Theme override to display a paragraph #type accordingly to the ECL library.
  *
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */

--- a/templates/paragraphs/paragraph.html.twig
+++ b/templates/paragraphs/paragraph.html.twig
@@ -1,41 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation to display a paragraph.
+ * Default theme implementation to display a paragraph accordingly to the ECL library.
  *
- * Available variables:
- * - paragraph: Full paragraph entity.
- *   Only method names starting with "get", "has", or "is" and a few common
- *   methods such as "id", "label", and "bundle" are available. For example:
- *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
- *   - paragraph.id(): The paragraph ID.
- *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
- *   - paragraph.getOwnerId(): The user ID of the paragraph author.
- *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
- *   and methods for the paragraph object.
- * - content: All paragraph items. Use {{ content }} to print them all,
- *   or print a subset such as {{ content.field_example }}. Use
- *   {{ content|without('field_example') }} to temporarily suppress the printing
- *   of a given child element.
- * - attributes: HTML attributes for the containing element.
- *   The attributes.class element may contain one or more of the following
- *   classes:
- *   - paragraphs: The current template type (also known as a "theming hook").
- *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
- *     "Image" it would result in "paragraphs--type--image". Note that the machine
- *     name will often be in a short form of the human readable label.
- *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
- *     preview would result in: "paragraphs--view-mode--preview", and
- *     default: "paragraphs--view-mode--default".
- * - view_mode: View mode; for example, "preview" or "full".
- * - logged_in: Flag for authenticated user status. Will be true when the
- *   current user is a logged-in member.
- * - is_admin: Flag for admin user status. Will be true when the current user
- *   is an administrator.
- *
- * @see template_preprocess_paragraph()
- *
- * @ingroup themeable
+ * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
 {% extends "@paragraphs/paragraph.html.twig" %}

--- a/templates/status/status-messages.html.twig
+++ b/templates/status/status-messages.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Theme override for a status messages accordingly to the ECL library.
+ * Theme override for a status messages.
  *
  * @see ./core/themes/stable/templates/misc/status-messages.html.twig
  */

--- a/templates/status/status-messages.html.twig
+++ b/templates/status/status-messages.html.twig
@@ -1,26 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation for status messages.
+ * Default theme implementation for status messages accordingly to the ECL library.
  *
- * Displays status, error, and warning messages, grouped by type.
- *
- * An invisible heading identifies the messages for assistive technology.
- * Sighted users see a colored box. See http://www.w3.org/TR/WCAG-TECHS/H69.html
- * for info.
- *
- * Add an ARIA label to the contentinfo area so that assistive technology
- * user agents will better describe this landmark.
- *
- * Available variables:
- * - message_list: List of messages to be displayed, grouped by type.
- * - status_headings: List of all status types.
- * - display: (optional) May have a value of 'status' or 'error' when only
- *   displaying messages of that specific type.
- * - attributes: HTML attributes for the element, including:
- *   - class: HTML classes.
- *
- * @ingroup themeable
+ *@see ./core/themes/stable/templates/misc/status-messages.html.twig
  */
 #}
 {% for type, messages in message_list %}

--- a/templates/status/status-messages.html.twig
+++ b/templates/status/status-messages.html.twig
@@ -1,9 +1,9 @@
 {#
 /**
  * @file
- * Default theme implementation for status messages accordingly to the ECL library.
+ * Theme override for a status messages accordingly to the ECL library.
  *
- *@see ./core/themes/stable/templates/misc/status-messages.html.twig
+ * @see ./core/themes/stable/templates/misc/status-messages.html.twig
  */
 #}
 {% for type, messages in message_list %}

--- a/templates/styleguide/styleguide-header.html.twig
+++ b/templates/styleguide/styleguide-header.html.twig
@@ -1,3 +1,11 @@
+{#
+/**
+ * @file
+ * Default theme implementation for styleguide contrib module.
+ *
+ *@see ./modules/contrib/styleguide/templates/styleguide-content.html.twig
+ */
+#}
 <h2>{{ "@name styleguide"|t({'@name': theme_info.name}) }}
 </h2>
 {% if theme_info.description %}

--- a/templates/styleguide/styleguide-header.html.twig
+++ b/templates/styleguide/styleguide-header.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation for styleguide contrib module.
+ * Theme override for a styleguide template.
  *
  *@see ./modules/contrib/styleguide/templates/styleguide-content.html.twig
  */


### PR DESCRIPTION
 1- Improve heredoc on Blocks template