### PR TITLE
OPENEUROPA-556: Fix breadcrumbs after ECL update and add kernel tests.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -15,8 +15,8 @@ use Drupal\Core\Render\Element;
 function oe_theme_preprocess_breadcrumb(&$variables) {
   $variables['segments'] = array_map(function ($item) {
     return [
-      'target' => $item['url'],
-      'title' => $item['text'],
+      'href' => $item['url'],
+      'label' => $item['text'],
     ];
   }, $variables['breadcrumb']);
 }

--- a/tests/Kernel/BreadcrumbTest.php
+++ b/tests/Kernel/BreadcrumbTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\Kernel;
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Link;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class BreadcrumbTest.
+ */
+class BreadcrumbTest extends AbstractKernelTest {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+  ];
+
+  /**
+   * Test a basic breadcrumb is themed using ECL breadcrumb component.
+   *
+   * @throws \Exception
+   */
+  public function testBreadcrumbRendering(): void {
+    $links = [
+      'Home' => '<front>',
+      'Test' => '<front>',
+    ];
+
+    $breadcrumb = new Breadcrumb();
+    foreach ($links as $title => $url) {
+      $breadcrumb->addLink(Link::createFromRoute($title, $url));
+
+    }
+    $render_array = $breadcrumb->toRenderable();
+    $html = $this->renderRoot($render_array);
+    $crawler = new Crawler($html);
+
+    // Assert wrapper contains ECL class.
+    $actual = $crawler->filter('nav.ecl-breadcrumbs');
+    $this->assertCount(1, $actual);
+
+    // Assert links are rendered correctly.
+    $position = 0;
+    foreach ($links as $title => $url) {
+      $link = $crawler->filter('ol.ecl-breadcrumbs__segments-wrapper li.ecl-breadcrumbs__segment a.ecl-breadcrumbs__link')->eq($position);
+      $this->assertEquals($title, trim($link->text()));
+      $position++;
+    }
+  }
+
+}

--- a/tests/Kernel/BreadcrumbTest.php
+++ b/tests/Kernel/BreadcrumbTest.php
@@ -34,7 +34,6 @@ class BreadcrumbTest extends AbstractKernelTest {
     $breadcrumb = new Breadcrumb();
     foreach ($links as $title => $url) {
       $breadcrumb->addLink(Link::createFromRoute($title, $url));
-
     }
     $render_array = $breadcrumb->toRenderable();
     $html = $this->renderRoot($render_array);


### PR DESCRIPTION
## OPENEUROPA-556

### Description

Fix breadcrumbs after the upgrade of ECL to 0.6.1. 
Add kernel tests to prevent issues in the future.

### Changelog

- Added: Add Kernel tests for breadcrumbs
- Fixed: Fix breadcrumbs after ECL update
