### PR TITLE
Language labels are translated in their native language.

### DIFF
--- a/tests/Kernel/LanguageSwitcherTest.php
+++ b/tests/Kernel/LanguageSwitcherTest.php
@@ -94,15 +94,15 @@ class LanguageSwitcherTest extends KernelTestBase {
     $this->assertEquals('en', $actual);
 
     $language_list = \Drupal::languageManager()->getStandardLanguageList();
-    $native_language_names = array_combine(array_keys($language_list), array_column($language_list, 1));
+    $language_names = array_combine(array_keys($language_list), array_column($language_list, 1));
     // Manage 2 special cases.
-    $native_language_names['pt'] = 'Português';
-    $native_language_names['mt'] = 'Malti';
+    $language_names['pt'] = 'Português';
+    $language_names['mt'] = 'Malti';
 
     // Make sure that language links are properly rendered.
     foreach (\Drupal::languageManager()->getLanguages() as $language) {
       $id = $language->getId();
-      $name = $native_language_names[$id];
+      $name = $language_names[$id];
       $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[lang={$id}]")->text();
       $this->assertEquals($name, trim($actual));
 

--- a/tests/Kernel/LanguageSwitcherTest.php
+++ b/tests/Kernel/LanguageSwitcherTest.php
@@ -93,14 +93,21 @@ class LanguageSwitcherTest extends KernelTestBase {
     $actual = $crawler->filter('a.ecl-lang-select-sites__link > .ecl-lang-select-sites__code > .ecl-lang-select-sites__code-text')->text();
     $this->assertEquals('en', $actual);
 
+    $language_list = \Drupal::languageManager()->getStandardLanguageList();
+    $native_language_names = array_combine(array_keys($language_list), array_column($language_list, 1));
+    // Manage 2 special cases.
+    $native_language_names['pt'] = 'Português';
+    $native_language_names['mt'] = 'Malti';
+
     // Make sure that language links are properly rendered.
     foreach (\Drupal::languageManager()->getLanguages() as $language) {
       $id = $language->getId();
+      $name = $native_language_names[$id];
       $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[lang={$id}]")->text();
-      $this->assertEquals($language->getName(), trim($actual));
+      $this->assertEquals($name, trim($actual));
 
       $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[hreflang={$id}]")->text();
-      $this->assertEquals($language->getName(), trim($actual));
+      $this->assertEquals($name, trim($actual));
     }
 
     // Make sure that English language link is set as active.

--- a/tests/features/theme-showcase.feature
+++ b/tests/features/theme-showcase.feature
@@ -52,6 +52,6 @@ Feature: Theme showcase
     Then the "language switcher link" element should contain "English"
 
     When I open the language switcher dialog
-    And I click "Polish"
+    And I click "Polski"
     Then the url should match "/pl"
-    And the "language switcher link" element should contain "Polish"
+    And the "language switcher link" element should contain "Polski"


### PR DESCRIPTION
Due to the changes in oe_multilingual, the tests regarding language labels are failing.