### PR TITLE
OPENEUROPA-677: New patch for @ECL node package

### DIFF
--- a/patches/@ecl/ec-component-list-item+1.0.1.patch
+++ b/patches/@ecl/ec-component-list-item+1.0.1.patch
@@ -1,0 +1,52 @@
+patch-package
+--- a/node_modules/@ecl/ec-component-list-item/ec-component-list-item.twig
++++ b/node_modules/@ecl/ec-component-list-item/ec-component-list-item.twig
+@@ -70,22 +70,33 @@
+       </div>
+     {% endif %}
+     <div class="ecl-list-item__body">
+-      <div class="ecl-list-item__meta">
+-        {% block meta_block %}
+-          {% include '@ecl/ec-component-meta' with { metas: _metas } only %}
+-        {% endblock %}
+-      </div>
++      {% if (_metas is not empty) %}
++        <div class="ecl-list-item__meta">
++          {% block meta_block %}
++            {% include '@ecl/ec-component-meta' with { metas: _metas } only %}
++          {% endblock %}
++        </div>
++      {% endif %}
++
++      {% if (title is not empty) %}
+       <h3 class="ecl-list-item__title ecl-heading ecl-heading--h3">{{ title }}</h3>
+-      <p class="ecl-list-item__detail ecl-paragraph">
+-        {% block detail_block %}
+-          {{ _detail }}
+-        {% endblock %}
+-      </p>
+-      <div class="ecl-list-item__action">
+-        {% block action_block %}
+-          {{ _action }}
+-        {% endblock %}
+-      </div>
++      {% endif %}
++
++      {% if (_detail is not empty) %}
++        <p class="ecl-list-item__detail ecl-paragraph">
++          {% block detail_block %}
++            {{ _detail }}
++          {% endblock %}
++        </p>
++      {% endif %}
++
++      {% if (_action is not empty) %}
++        <div class="ecl-list-item__action">
++          {% block action_block %}
++            {{ _action }}
++          {% endblock %}
++        </div>
++      {% endif %}
+     </div>
+     {% if _secondary_image is not empty %}
+     <div class="ecl-list-item__secondary">

--- a/tests/Kernel/ParagraphsTest.php
+++ b/tests/Kernel/ParagraphsTest.php
@@ -233,7 +233,7 @@ class ParagraphsTest extends AbstractKernelTestBase {
     $this->assertCount(1, $crawler->filter('.ecl-list-item.ecl-list-item--highlight'));
     $this->assertEquals('Item title', trim($crawler->filter('.ecl-list-item__title')->text()));
     // The description should not be rendered in this variant.
-    $this->assertEquals('', trim($crawler->filter('.ecl-list-item__detail')->text()));
+    $this->assertCount(0, $crawler->filter('.ecl-list-item__detail'));
     // Neither the date.
     $this->assertCount(0, $crawler->filter('.ecl-date-block__week-day'));
     $this->assertCount(0, $crawler->filter('.ecl-date-block__day'));

--- a/tests/fixtures/rendering.yml
+++ b/tests/fixtures/rendering.yml
@@ -217,9 +217,9 @@
       'a.ecl-list-item__link[href="http://example.com"]': 1
       '.ecl-list-item__primary img.ecl-image[src="http://via.placeholder.com/300x300"][alt="Alternate text for image"]': 1
       '.ecl-list-item__secondary': 0
+      'p.ecl-list-item__detail': 0
     equals:
       'h3.ecl-list-item__title': "Item title"
-      'p.ecl-list-item__detail': ""
 - array:
     '#type': pattern
     '#id': list_item_block_one_column
@@ -451,3 +451,15 @@
       'span.ecl-social-icon--facebook': 1
     equals:
       'span.ecl-social-icon--facebook': "Facebook"
+- array:
+    '#type': pattern
+    '#id': list_item_default
+    '#fields':
+      url: "http://example.com"
+      title: ""
+      detail: ""
+  assertions:
+    count:
+      'a.ecl-list-item__link[href="http://example.com"]': 1
+      'h3.ecl-list-item__title.ecl-heading.ecl-heading--h3': 0
+      'p.ecl-list-item__detail.ecl-paragraph': 0


### PR DESCRIPTION
New patch for @ECL node package to prevent empty sections to be rendered in EC Component List Item.