### PR TITLE
OPENEUROPA-722: Make sure the default body classes are output

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "^1",
-        "drupal/drupal-extension": "^3.4",
+        "drupal/drupal-extension": "^4.0",
         "drush/drush": "^9",
         "nikic/php-parser": "~3",
         "openeuropa/code-review": "~0.3",
@@ -55,6 +55,14 @@
         "patches": {
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-07-05/2943172-kernel-test-base-3.patch"
+            }
+        },
+        "patches-ignore": {
+            "openeuropa/oe_multilingual": {
+                "drupal/core": {
+                    "https://www.drupal.org/project/drupal/issues/2943172": "https://www.drupal.org/files/issues/2018-04-15/2943172-kernel-test-base-2.patch",
+                    "https://www.drupal.org/project/drupal/issues/2599228": "https://www.drupal.org/files/issues/2599228-31-tests-only.patch"
+                }
             }
         },
         "installer-paths": {

--- a/templates/html/html.html.twig
+++ b/templates/html/html.html.twig
@@ -8,6 +8,8 @@
 #}
 {%
     set body_classes = [
+        'language-' ~ html_attributes.lang,
+        'ecl-typography',
         logged_in ? 'user-logged-in',
         not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
         node_type ? 'page-node-type-' ~ node_type|clean_class,
@@ -22,7 +24,7 @@
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
   </head>
-  <body{{ attributes.addClass('language-' ~ html_attributes.lang).addClass('ecl-typography').addClass(body_classes) }}>
+  <body{{ attributes.addClass(body_classes) }}>
     {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.

--- a/templates/html/html.html.twig
+++ b/templates/html/html.html.twig
@@ -6,6 +6,14 @@
  * @see ./core/themes/stable/templates/layout/html.html.twig
  */
 #}
+{%
+    set body_classes = [
+        logged_in ? 'user-logged-in',
+        not root_path ? 'path-frontpage' : 'path-' ~ root_path|clean_class,
+        node_type ? 'page-node-type-' ~ node_type|clean_class,
+        db_offline ? 'db-offline',
+    ]
+%}
 <!DOCTYPE html>
 <html{{ html_attributes }}>
   <head>
@@ -14,7 +22,7 @@
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
   </head>
-  <body{{ attributes.addClass('language-' ~ html_attributes.lang).addClass('ecl-typography') }}>
+  <body{{ attributes.addClass('language-' ~ html_attributes.lang).addClass('ecl-typography').addClass(body_classes) }}>
     {#
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.

--- a/tests/features/authentication.feature
+++ b/tests/features/authentication.feature
@@ -1,0 +1,10 @@
+@api
+Feature: Authentication
+  In order to allow personalized actions to be taken
+  As a product owner
+  I need to make sure that we can detect the user's authentication status in the frontend
+
+  Scenario:
+    # Behat Drupal Extension 4.x determines the logged in status by inspecting
+    # the DOM. This will fail if the status cannot be derived from the frontend.
+    Given I am logged in as a user with the "authenticated" role


### PR DESCRIPTION
The theme misses the important body classes that are used to identify whether the user is logged in, visiting an admin page, the node type etc. Without these it will not be possible to write effective JS, and the functional tests are also failing.

Ref. `template_preprocess_html()`
Ref. `html.html.twig` in the Classy theme.