### PR TITLE
Update drupal scaffold

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal-composer/drupal-scaffold": "^2.2",
+        "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "^1",
         "drupal/drupal-extension": "^4.0",
@@ -30,7 +30,6 @@
         "webflo/drupal-core-require-dev": "~8.6@alpha"
     },
     "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"
     },


### PR DESCRIPTION
I'm getting an error when installing the composer dependencies:

```
PHP Fatal error:  Uncaught TypeError: Argument 3 passed to DrupalComposer\DrupalScaffold\PrestissimoFileFetcher::__construct() must implement interface Composer\IO\IOInterface, array given, called in /home/pieter/v/oe_theme/vendor/drupal-composer/drupal-scaffold/src/Handler.php on line 117 and defined in /home/pieter/v/oe_theme/vendor/drupal-composer/drupal-scaffold/src/PrestissimoFileFetcher.php:25
```

This is due to https://github.com/drupal-composer/drupal-scaffold/issues/79 for which a fix is released in drupal-scaffold 2.5.2.

This is a require-dev dependency so this version restriction does not affect the dependency chains of the websites that uses of the theme.