### PR TITLE
OPENEUROPA-9: Update Drupal Scaffold.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require-dev": {
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "~1.0",
-        "drupal-composer/drupal-scaffold": "^2.2",
+        "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "^1",
         "drupal/drupal-extension": "^4.0",
@@ -30,7 +30,6 @@
         "webflo/drupal-core-require-dev": "~8.6@alpha"
     },
     "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"
     },


### PR DESCRIPTION
The latest version no longer requires additional configuration in the
composer.json file.