### PR TITLE
OPENEUROPA-1381: Use Url objects on ui_patterns.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -533,7 +533,7 @@ function oe_theme_preprocess_paragraph__oe_list_item(array &$variables): void {
   $list_item_variant = $paragraph->get('field_oe_list_item_variant')->first()->value;
 
   $variables['variant'] = $variants[$list_item_variant] ?? 'default';
-  $variables['url'] = $paragraph->get('field_oe_link')->first()->getUrl()->toString();
+  $variables['url'] = $paragraph->get('field_oe_link')->first()->getUrl();
 
   $cacheability = CacheableMetadata::createFromRenderArray($variables);
 
@@ -597,7 +597,7 @@ function oe_theme_preprocess_paragraph__oe_list_item_block(array &$variables): v
 
   /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem $link_item */
   $link_item = $paragraph->get('field_oe_link')->first();
-  $variables['button_url'] = $link_item->getUrl()->toString();
+  $variables['button_url'] = $link_item->getUrl();
   $variables['button_label'] = $link_item->get('title')->getValue();
 }
 

--- a/templates/patterns/banners/banner_hero.ui_patterns.yml
+++ b/templates/patterns/banners/banner_hero.ui_patterns.yml
@@ -15,9 +15,9 @@ banner_hero:
       description: "Hero title"
       preview: "White Paper on the future of Europe"
     url:
-      type: "text"
+      type: "Url"
       label: "URL"
-      description: "List item link URL"
+      description: "List item link URL (A Drupal Url object)"
       preview: "#"
     description:
       type: "text"

--- a/templates/patterns/button/button.ui_patterns.yml
+++ b/templates/patterns/button/button.ui_patterns.yml
@@ -30,9 +30,9 @@ button:
       description: "The buttons type attribute"
       preview: "submit"
     href:
-      type: "text"
+      type: "Url"
       label: "URL"
-      description: "URL to use if button needs to be a link"
+      description: "URL to use if button needs to be a link (A Drupal Url object)"
       preview: "http://www.example.com"
     icon:
       type: "text"

--- a/templates/patterns/file_image/file_image.ui_patterns.yml
+++ b/templates/patterns/file_image/file_image.ui_patterns.yml
@@ -3,9 +3,9 @@ file_image:
   description: "Displays the file image."
   fields:
     src:
-      type: "text"
+      type: "Url"
       label: "Source"
-      description: "Source of the image"
+      description: "Source of the image (A Drupal Url object)"
       preview: "https://placehold.it/450x250"
     alt:
       type: "text"

--- a/templates/patterns/file_video/file_video.ui_patterns.yml
+++ b/templates/patterns/file_video/file_video.ui_patterns.yml
@@ -3,9 +3,9 @@ file_video:
   description: "Displays the file video."
   fields:
     src:
-      type: "text"
+      type: "Url"
       label: "Source"
-      description: "Source of the video."
+      description: "Source of the video (A Drupal Url object)"
       preview: "https://ec.europa.eu/avservices/play.cfm?ref=I101631"
     caption:
       type: "text"

--- a/templates/patterns/list_item/list_item.ui_patterns.yml
+++ b/templates/patterns/list_item/list_item.ui_patterns.yml
@@ -25,9 +25,9 @@ list_item:
       description: "Thumbnail list item, contains a secondary image, metadata information and a linked title."
   fields:
     url:
-      type: "text"
+      type: "Url"
       label: "URL"
-      description: "List item link URL"
+      description: "List item link URL (A Drupal Url object)"
       preview: "#"
     title:
       type: "text"

--- a/templates/patterns/list_item_blocks/list_item_block_one_column.ui_patterns.yml
+++ b/templates/patterns/list_item_blocks/list_item_block_one_column.ui_patterns.yml
@@ -33,7 +33,7 @@ list_item_block_one_column:
       description: "Call to action label"
       preview: "View all"
     button_url:
-      type: "text"
-      label: "Button URL"
+      type: "Url"
+      label: "Button URL (A Drupal Url object)"
       description: "Call to action URL"
       preview: "#"

--- a/templates/patterns/list_item_blocks/list_item_block_three_columns.ui_patterns.yml
+++ b/templates/patterns/list_item_blocks/list_item_block_three_columns.ui_patterns.yml
@@ -48,7 +48,7 @@ list_item_block_three_columns:
       description: "Call to action label"
       preview: "View all"
     button_url:
-      type: "text"
-      label: "Button URL"
+      type: "Url"
+      label: "Button URL (A Drupal Url object)"
       description: "Call to action URL"
       preview: "#"

--- a/templates/patterns/list_item_blocks/list_item_block_two_columns.ui_patterns.yml
+++ b/templates/patterns/list_item_blocks/list_item_block_two_columns.ui_patterns.yml
@@ -38,7 +38,7 @@ list_item_block_two_columns:
       description: "Call to action label"
       preview: "View all"
     button_url:
-      type: "text"
-      label: "Button URL"
+      type: "Url"
+      label: "Button URL (A Drupal Url object)"
       description: "Call to action URL"
       preview: "#"

--- a/templates/patterns/social_icon/social_icon.ui_patterns.yml
+++ b/templates/patterns/social_icon/social_icon.ui_patterns.yml
@@ -13,7 +13,7 @@ social_icon:
       description: "Label accompanying the social icon."
       preview: "Facebook"
     url:
-      type: "string"
+      type: "Url"
       label: "URL"
-      description: "URL to link the social icon to. Optional."
+      description: "URL to link the social icon to. Optional. (A Drupal Url object)"
       preview: "http://example.com"


### PR DESCRIPTION
## OPENEUROPA-1381
### Description

Use Drupal core \Drupal\Core\Url objects wherever necessary in custom ui_patterns.

### Change log

- Changed: Url fields on ui_patterns now use \Drupal\Core\Url objects