### PR TITLE
OPENEUROPA-1387: Move "Deprecation warnings in Twig" patch to openeuropa/drupal-core-require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "nikic/php-parser": "~3.0",
         "openeuropa/code-review": "^1.0.0-alpha4",
         "openeuropa/behat-transformation-context" : "~0.1",
-        "openeuropa/drupal-core-require-dev": "^8.6",
+        "openeuropa/drupal-core-require-dev": "8.6.x-dev",
         "openeuropa/oe_multilingual": "~0.2.1",
         "openeuropa/oe_paragraphs": "~0.3",
         "openeuropa/task-runner": "~1.0-beta3",
@@ -52,11 +52,6 @@
     "extra": {
         "composer-exit-on-patch-failure": true,
         "enable-patching": true,
-        "patches": {
-            "drupal/core": {
-                "Deprecation warnings in Twig code cause test failures. https://www.drupal.org/project/drupal/issues/2600154": "https://www.drupal.org/files/issues/2018-08-13/2600154-3-60.patch"
-            }
-        },
         "installer-paths": {
             "build/core": ["type:drupal-core"],
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],


### PR DESCRIPTION
## OPENEUROPA-1387

### Description

Move "Deprecation warnings in Twig" patch to openeuropa/drupal-core-require-dev

### Change log

- Updated: the dependency "openeuropa/drupal-core-require-dev"
- Removed: Remove the patch "Deprecation warnings in Twig code cause test failures."
