### PR TITLE
OPENEUROPA-1549: Renaming config to actually get imported.

### DIFF
--- a/config/optional/block.block.oe_theme_content_language_switcher.yml
+++ b/config/optional/block.block.oe_theme_content_language_switcher.yml
@@ -5,7 +5,7 @@ dependencies:
     - oe_multilingual
   theme:
     - oe_theme
-id: oe_multilingual_content_language_switcher
+id: oe_theme_content_language_switcher
 theme: oe_theme
 region: content
 weight: 1

--- a/config/optional/block.block.oe_theme_language_switcher.yml
+++ b/config/optional/block.block.oe_theme_language_switcher.yml
@@ -5,7 +5,7 @@ dependencies:
     - language
   theme:
     - oe_theme
-id: oe_multilingual_language_switcher
+id: oe_theme_language_switcher
 theme: oe_theme
 region: site_header
 weight: 1


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

The configs need to be renamed to actually work. Shipped config needs to be within the namespace of the module.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

