### PR TITLE
OPENEUROPA-1680: Making the page header block alterable.

### DIFF
--- a/modules/oe_theme_helper/src/Event/PageHeaderAlterEvent.php
+++ b/modules/oe_theme_helper/src/Event/PageHeaderAlterEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_helper\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event dispatched after the page header has been assembled.
+ *
+ * It allows alterations of the elements that make up the page header.
+ */
+class PageHeaderAlterEvent extends Event {
+
+  /**
+   * The event name used when dispatching this event.
+   */
+  const EVENT_NAME = 'page_header.alter';
+
+  /**
+   * The element.
+   *
+   * @var array
+   */
+  protected $element;
+
+  /**
+   * Returns the element.
+   *
+   * @return array
+   *   The element.
+   */
+  public function getElement(): array {
+    return $this->element;
+  }
+
+  /**
+   * Sets the element.
+   *
+   * @param array $element
+   *   The element.
+   */
+  public function setElement(array $element): void {
+    $this->element = $element;
+  }
+
+}

--- a/tests/Kernel/PageHeaderTest.php
+++ b/tests/Kernel/PageHeaderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\Kernel;
+
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\Tests\oe_theme\Traits\RenderTrait;
+use Drupal\Tests\oe_theme\Traits\RequestTrait;
+
+/**
+ * Tests the page header block functionality.
+ */
+class PageHeaderTest extends EntityKernelTestBase {
+
+  use RequestTrait;
+  use RenderTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'ui_patterns',
+    'oe_theme_helper',
+    'oe_theme_page_header_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installConfig(['system']);
+
+    $this->container->get('theme_installer')->install(['oe_theme']);
+    $this->container->get('theme_handler')->setDefault('oe_theme');
+    $this->container->set('theme.registry', NULL);
+  }
+
+  /**
+   * Tests that we can alter the page header block using a subscriber.
+   *
+   * @param string $context_title
+   *   The title to be sent to the context.
+   * @param string $expected_title
+   *   The expected title upon rendering.
+   *
+   * @dataProvider pageAlterDataProvider
+   */
+  public function testPageHeaderAlter(string $context_title, string $expected_title): void {
+    /** @var \Drupal\Core\Block\BlockBase $plugin */
+    $plugin = $this->container->get('plugin.manager.block')->createInstance('oe_theme_helper_page_header', []);
+    $contexts = [
+      'page_header' => new Context(new ContextDefinition('map', 'Metadata'), [
+        'title' => $context_title,
+      ]),
+    ];
+    $this->container->get('context.handler')->applyContextMapping($plugin, $contexts);
+    $build = $plugin->build();
+    $this->assertEquals($expected_title, $build['#title']);
+  }
+
+  /**
+   * Provides different titles to test the alteration of the page header block.
+   *
+   * @see self::testPageHeaderAlter()
+   *
+   * @return array
+   *   The data
+   */
+  public function pageAlterDataProvider() {
+    return [
+      ['My title', 'My title'],
+      ['Alter it', 'Altered title'],
+    ];
+  }
+
+}

--- a/tests/modules/oe_theme_page_header_test/oe_theme_page_header_test.info.yml
+++ b/tests/modules/oe_theme_page_header_test/oe_theme_page_header_test.info.yml
@@ -1,0 +1,5 @@
+name: OE Theme Page Header Test
+description: Test module for the Page Header block.
+core: 8.x
+type: module
+package: Testing

--- a/tests/modules/oe_theme_page_header_test/oe_theme_page_header_test.services.yml
+++ b/tests/modules/oe_theme_page_header_test/oe_theme_page_header_test.services.yml
@@ -1,0 +1,5 @@
+services:
+  oe_theme_page_header_test.page_header_alter_test:
+    class: Drupal\oe_theme_page_header_test\EventSubscriber\PageHeaderAlterTestSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/tests/modules/oe_theme_page_header_test/src/EventSubscriber/PageHeaderAlterTestSubscriber.php
+++ b/tests/modules/oe_theme_page_header_test/src/EventSubscriber/PageHeaderAlterTestSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_page_header_test\EventSubscriber;
+
+use Drupal\oe_theme_helper\Event\PageHeaderAlterEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber that changes the title of the page header.
+ */
+class PageHeaderAlterTestSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[PageHeaderAlterEvent::EVENT_NAME][] = ['onPageHeaderBuild', 0];
+    return $events;
+  }
+
+  /**
+   * Performs the alterations.
+   *
+   * @param \Drupal\oe_theme_helper\Event\PageHeaderAlterEvent $event
+   *   The event object.
+   */
+  public function onPageHeaderBuild(PageHeaderAlterEvent $event) {
+    $element = $event->getElement();
+    if ($element['#title'] == 'Alter it') {
+      $element['#title'] = 'Altered title';
+    }
+    $event->setElement($element);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-1680

### Description

Added an event dispatcher to make the page header alterable.

This is needed for the breadcrumb alterations in EWCMS

