### PR TITLE
OPENEUROPA-1724: Modify processing of date fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
+        "drupal/drupal-driver": "~2.0.0-alpha6",
         "drupal/drupal-extension": "~4.0",
         "drupal/styleguide": "~1.0-alpha3",
         "drush/drush": "~9.0",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^7.1"
     },
     "require-dev": {
+        "cweagans/composer-patches": "~1.0",
         "composer/installers": "~1.5",
         "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
@@ -62,6 +63,11 @@
             "build/profiles/contrib/{$name}": ["type:drupal-profile"],
             "build/modules/contrib/{$name}": ["type:drupal-module"],
             "build/themes/contrib/{$name}": ["type:drupal-theme"]
+        },
+        "patches": {
+            "drupal/drupal-driver": {
+                "allow-date-only-date-fields": "https://patch-diff.githubusercontent.com/raw/jhedstrom/DrupalDriver/pull/201.patch"
+            }
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.6.4",
-        "openeuropa/oe_content": "dev-OPENEUROPA-1724",
+        "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "dev-master",
         "openeuropa/oe_multilingual": "~0.3.1",
         "openeuropa/oe_paragraphs": "~0.4",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.6.4",
-        "openeuropa/oe_content": "dev-master",
+        "openeuropa/oe_content": "dev-OPENEUROPA-1724",
         "openeuropa/oe_corporate_blocks": "dev-master",
         "openeuropa/oe_multilingual": "~0.3.1",
         "openeuropa/oe_paragraphs": "~0.4",

--- a/modules/oe_theme_content_news/oe_theme_content_news.module
+++ b/modules/oe_theme_content_news/oe_theme_content_news.module
@@ -46,7 +46,7 @@ function oe_theme_content_news_preprocess_node__oe_news__teaser(&$variables) {
   $variables['title'] = !$node->get('oe_content_short_title')->isEmpty() ? $node->get('oe_content_short_title')->value : $node->label();
 
   $date_formatter = \Drupal::service('date.formatter');
-  $variables['meta'][] = $date_formatter->format($node->get('oe_news_publication_date')->value, 'oe_theme_news_date');
+  $variables['meta'][] = $date_formatter->format($node->get('oe_news_publication_date')->date->getTimestamp(), 'oe_theme_news_date');
 
   $media = $node->get('oe_news_featured_media')->entity;
   if (!$media instanceof MediaInterface) {

--- a/modules/oe_theme_content_news/src/Plugin/PageHeaderMetadata/NewsContentType.php
+++ b/modules/oe_theme_content_news/src/Plugin/PageHeaderMetadata/NewsContentType.php
@@ -90,7 +90,7 @@ class NewsContentType extends EntityCanonicalRoutePage {
       ];
     }
 
-    $timestamp = $entity->get('oe_news_publication_date')->value;
+    $timestamp = $entity->get('oe_news_publication_date')->date->getTimestamp();
     $metadata['metas'] = [
       $this->t('News'),
       $this->dateFormatter->format($timestamp, 'oe_theme_news_date'),

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -8,7 +8,7 @@ Feature: News content type.
   Scenario: News information is shown in teasers.
     Given "oe_news" content:
       | title           | oe_news_summary | oe_news_teaser | body      | oe_news_publication_date | oe_news_subject                | oe_news_author                                                          | oe_content_content_owner                                                |
-      | Full news title | Short summary   | News teaser    | News body | 1554197428               | http://data.europa.eu/uxp/1000 | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH |
+      | Full news title | Short summary   | News teaser    | News body | 2019-04-02               | http://data.europa.eu/uxp/1000 | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH |
 
     When I am on "the recent content page"
     Then I should see the heading "Full news title"

--- a/tests/features/page-header.feature
+++ b/tests/features/page-header.feature
@@ -57,7 +57,7 @@ Feature: Page header block component.
   Scenario: News content type has custom metadata shown in the page header.
     Given "oe_news" content:
       | title        | oe_news_summary | oe_news_teaser | body    | oe_news_publication_date | oe_news_subject                | oe_news_author                                                          | oe_content_content_owner                                                |
-      | My news item | My summary      | My teaser      | My body | 1554197428               | http://data.europa.eu/uxp/1000 | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH |
+      | My news item | My summary      | My teaser      | My body | 2019-04-02               | http://data.europa.eu/uxp/1000 | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH |
     And I am an anonymous user
     When I go to the "My news item" page
     Then I should see "My summary" in the "page header intro"


### PR DESCRIPTION
## OPENEUROPA-1724

### Description

The publication date changed form timestamp to datefield. Change configuration and tests to reflect this.

### Change log

- Added:
- Changed: Change configuration and tests to reflect change in publication date field.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

