### PR TITLE
OPENEUROPA-1806: PT-PT language switcher bug fix

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -386,11 +386,16 @@ function oe_theme_preprocess_links__language_block(array &$variables): void {
       ->setAbsolute(TRUE)
       ->toString();
 
+    // Get the language prefix.
+    $lang_prefix = \Drupal::configFactory()
+      ->getEditable('language.negotiation')
+      ->get('url.prefixes.' . $language_code);
+
     $variables['languages'][] = [
       'href' => $href,
       'hreflang' => $language_code,
       'label' => $link['link']['#title'],
-      'lang' => $language_code,
+      'lang' => $lang_prefix,
       'is_active' => $language_code === $current_language,
     ];
   }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -388,7 +388,7 @@ function oe_theme_preprocess_links__language_block(array &$variables): void {
 
     // Get the language prefix.
     $lang_prefix = \Drupal::configFactory()
-      ->getEditable('language.negotiation')
+      ->get('language.negotiation')
       ->get('url.prefixes.' . $language_code);
 
     $variables['languages'][] = [

--- a/tests/Kernel/LanguageSwitcherTest.php
+++ b/tests/Kernel/LanguageSwitcherTest.php
@@ -29,10 +29,10 @@ class LanguageSwitcherTest extends MultilingualAbstractKernelTestBase {
     /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
     $languages = $this->container->get('language_manager')->getNativeLanguages();
 
-    $lang_config = \Drupal::configFactory()->getEditable('language.negotiation');
+    $lang_config = $this->container->get('config.factory')->get('language.negotiation');
 
     // Make sure that language links are properly rendered.
-    foreach (\Drupal::languageManager()->getLanguages() as $language) {
+    foreach ($this->container->get('language_manager')->getLanguages() as $language) {
       $id = $language->getId();
       $name = $languages[$id]->getName();
 
@@ -83,7 +83,7 @@ class LanguageSwitcherTest extends MultilingualAbstractKernelTestBase {
    * Data provider for the rendering test.
    *
    * @return array
-   *   An array of langcodes.
+   *   An array of langcodes and prefixes.
    */
   public function renderingDataProvider(): array {
     return [

--- a/tests/Kernel/LanguageSwitcherTest.php
+++ b/tests/Kernel/LanguageSwitcherTest.php
@@ -121,7 +121,7 @@ class LanguageSwitcherTest extends MultilingualAbstractKernelTestBase {
    *   Return the crawler.
    */
   protected function renderLanguageBlock(): Crawler {
-    $block_manager = \Drupal::service('plugin.manager.block');
+    $block_manager = $this->container->get('plugin.manager.block');
     $config = [
       'id' => 'language_block:language_interface',
       'label' => 'Language switcher',

--- a/tests/Kernel/LanguageSwitcherTest.php
+++ b/tests/Kernel/LanguageSwitcherTest.php
@@ -12,11 +12,114 @@ use Symfony\Component\DomCrawler\Crawler;
 class LanguageSwitcherTest extends MultilingualAbstractKernelTestBase {
 
   /**
-   * Test language switcher rendering.
+   * Test language switcher link list rendering.
    */
-  public function testLanguageSwitcherRendering(): void {
+  public function testLanguageSwitcherLinkListRendering(): void {
+    // Build the language block.
+    $crawler = $this->renderLanguageBlock();
 
-    // Setup and render language switcher block.
+    // Make sure that language switcher overlay is present.
+    $actual = $crawler->filter('.ecl-language-list.ecl-language-list--overlay');
+    $this->assertCount(1, $actual);
+
+    /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
+    $languages = \Drupal::service('language_manager')->getNativeLanguages();
+
+    // Make sure that language links are properly rendered.
+    foreach (\Drupal::languageManager()->getLanguages() as $language) {
+      $id = $language->getId();
+      $name = $languages[$id]->getName();
+
+      // Get the language prefix.
+      $lang_prefix = \Drupal::configFactory()
+        ->getEditable('language.negotiation')
+        ->get('url.prefixes.' . $id);
+
+      $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[lang={$lang_prefix}]")->text();
+      $this->assertEquals($name, trim($actual));
+
+      $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[hreflang={$id}]")->text();
+      $this->assertEquals($name, trim($actual));
+    }
+  }
+
+  /**
+   * Test language switcher rendering.
+   *
+   * @dataProvider renderingDataProvider
+   */
+  public function testLanguageSwitcherRendering($langcode): void {
+    // Set the site default language.
+    $this->config('system.site')->set('default_langcode', $langcode)->save();
+
+    // Build the language block.
+    $crawler = $this->renderLanguageBlock();
+
+    // Make sure that language switcher overlay title is set.
+    $actual = $crawler->filter('.ecl-dialog .ecl-dialog__title')->text();
+    $this->assertEquals('Select your language', trim($actual));
+
+    /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
+    $languages = \Drupal::service('language_manager')->getNativeLanguages();
+
+    // Make sure that language switcher link is properly rendered.
+    $actual = $crawler->filter('a.ecl-lang-select-sites__link > .ecl-lang-select-sites__label')->text();
+    $this->assertEquals($languages[$langcode]->getName(), $actual);
+
+    // Get the language prefix.
+    $lang_prefix = \Drupal::configFactory()
+      ->getEditable('language.negotiation')
+      ->get('url.prefixes.' . $langcode);
+    $actual = $crawler->filter('a.ecl-lang-select-sites__link > .ecl-lang-select-sites__code > .ecl-lang-select-sites__code-text')->text();
+    $this->assertEquals($lang_prefix, $actual);
+
+    // Make sure that English language link is set as active.
+    $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button--active[lang={$lang_prefix}]")->text();
+    $this->assertEquals($languages[$langcode]->getName(), trim($actual));
+  }
+
+  /**
+   * Data provider for the rendering test.
+   *
+   * @return array
+   *   An array of langcodes.
+   */
+  public function renderingDataProvider(): array {
+    return [
+      ['bg'],
+      ['cs'],
+      ['da'],
+      ['de'],
+      ['et'],
+      ['el'],
+      ['en'],
+      ['es'],
+      ['fr'],
+      ['ga'],
+      ['hr'],
+      ['it'],
+      ['lv'],
+      ['lt'],
+      ['hu'],
+      ['mt'],
+      ['nl'],
+      ['pl'],
+      ['pt-pt'],
+      ['ro'],
+      ['sk'],
+      ['sl'],
+      ['fi'],
+      ['sv'],
+    ];
+  }
+
+  /**
+   * Setup and render the language switcher block.
+   *
+   * @return \Symfony\Component\DomCrawler\Crawler
+   *   Return the clawler.
+   */
+  protected function renderLanguageBlock(): Crawler {
     $block_manager = \Drupal::service('plugin.manager.block');
     $config = [
       'id' => 'language_block:language_interface',
@@ -28,42 +131,9 @@ class LanguageSwitcherTest extends MultilingualAbstractKernelTestBase {
     /** @var \Drupal\Core\Block\BlockBase $plugin_block */
     $plugin_block = $block_manager->createInstance('language_block:language_interface', $config);
     $render = $plugin_block->build();
-
     $html = (string) $this->container->get('renderer')->renderRoot($render);
-    $crawler = new Crawler($html);
 
-    // Make sure that language switcher overlay is present.
-    $actual = $crawler->filter('.ecl-language-list.ecl-language-list--overlay');
-    $this->assertCount(1, $actual);
-
-    // Make sure that language switcher overlay title is set.
-    $actual = $crawler->filter('.ecl-dialog .ecl-dialog__title')->text();
-    $this->assertEquals('Select your language', trim($actual));
-
-    // Make sure that language switcher link is properly rendered.
-    $actual = $crawler->filter('a.ecl-lang-select-sites__link > .ecl-lang-select-sites__label')->text();
-    $this->assertEquals('English', $actual);
-
-    $actual = $crawler->filter('a.ecl-lang-select-sites__link > .ecl-lang-select-sites__code > .ecl-lang-select-sites__code-text')->text();
-    $this->assertEquals('en', $actual);
-
-    /** @var \Drupal\Core\Language\LanguageInterface[] $languages */
-    $languages = \Drupal::service('language_manager')->getNativeLanguages();
-
-    // Make sure that language links are properly rendered.
-    foreach (\Drupal::languageManager()->getLanguages() as $language) {
-      $id = $language->getId();
-      $name = $languages[$id]->getName();
-      $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[lang={$id}]")->text();
-      $this->assertEquals($name, trim($actual));
-
-      $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button[hreflang={$id}]")->text();
-      $this->assertEquals($name, trim($actual));
-    }
-
-    // Make sure that English language link is set as active.
-    $actual = $crawler->filter(".ecl-dialog a.ecl-language-list__button--active[lang=en]")->text();
-    $this->assertEquals('English', trim($actual));
+    return new Crawler($html);
   }
 
 }


### PR DESCRIPTION
Make sure that the language switcher uses the prefix instead of the langcode.