### PR TITLE
OPENEUROPA-1807: featured_image must be after content_moderation_control

### DIFF
--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * The OE Theme Helper module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+
+/**
+ * Implements hook_entity_view_alter().
+ */
+function oe_theme_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  if (!isset($build['content_moderation_control'])) {
+    return;
+  }
+
+  // Ensure that the content moderation control block will always
+  // show at the top, above any other elements.
+  $build['content_moderation_control']['#weight'] = -500;
+}


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

Change weight for `featured_image` to appear after `content_moderation_control`.

### Change log

- Changed: Weight for `featured_image` decreased from -100 to -19.
