### PR TITLE
OPENEUROPA-1775: Add responsive image formatter.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,10 +31,9 @@
         "openeuropa/oe_multilingual": "~0.3.1",
         "openeuropa/oe_paragraphs": "~0.5",
         "openeuropa/oe_search": "~1.0",
-        "openeuropa/task-runner": "~1.0@beta",
+        "openeuropa/task-runner": "^1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.4",
-        "drupal/media_avportal": "dev-OPENEUROPA-1775 as 1.0-beta1"
+        "symfony/dom-crawler": "~3.4"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -52,10 +51,6 @@
         }
     },
     "repositories": {
-        "media_avportal": {
-            "url": "git@github.com:openeuropa/media_avportal.git",
-            "type": "vcs"
-        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,15 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0@beta",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "~0.6",
+        "openeuropa/oe_content": "^1.0@beta",
         "openeuropa/oe_corporate_blocks": "~1.0",
         "openeuropa/oe_multilingual": "~0.3.1",
         "openeuropa/oe_paragraphs": "~0.5",
         "openeuropa/oe_search": "~1.0",
         "openeuropa/task-runner": "~1.0@beta",
         "phpunit/phpunit": "~6.0",
-        "symfony/dom-crawler": "~3.4"
+        "symfony/dom-crawler": "~3.4",
+        "drupal/media_avportal": "dev-OPENEUROPA-1775 as 1.0-beta1"
     },
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
@@ -51,6 +52,10 @@
         }
     },
     "repositories": {
+        "media_avportal": {
+            "url": "git@github.com:openeuropa/media_avportal.git",
+            "type": "vcs"
+        },
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,8 @@
     "require-dev": {
         "cweagans/composer-patches": "~1.0",
         "composer/installers": "~1.5",
+        "consolidation/robo": "~1.4",
+        "consolidation/annotated-command": "^2.8.2",
         "drupal-composer/drupal-scaffold": "^2.5.2",
         "drupal/config_devel": "~1.2",
         "drupal/console": "~1.0",
@@ -35,6 +37,10 @@
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.4"
     },
+    "_readme": [
+        "We explicitly require consolidation/robo to allow lower 'composer update --prefer-lowest' to complete successfully.",
+        "We explicitly require consolidation/annotated-command to allow lower 'composer update --prefer-lowest' to complete successfully."
+    ],
     "scripts": {
         "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",

--- a/config/optional/core.entity_view_display.media.av_portal_photo.oe_theme_main_content.yml
+++ b/config/optional/core.entity_view_display.media.av_portal_photo.oe_theme_main_content.yml
@@ -17,9 +17,9 @@ content:
     weight: 0
     label: hidden
     settings:
-      image_style: oe_theme_small_no_crop
+      responsive_image_style: oe_theme_main_content
     third_party_settings: {  }
-    type: avportal_photo
+    type: avportal_photo_responsive
     region: content
 hidden:
   created: true

--- a/modules/oe_theme_helper/oe_theme_helper.install
+++ b/modules/oe_theme_helper/oe_theme_helper.install
@@ -45,7 +45,7 @@ function oe_theme_helper_update_8001(): ?MarkupInterface {
 /**
  * Update AV Photo media display configuration.
  */
-function oe_theme_helper_update_8001() {
+function oe_theme_helper_update_8002() {
   $storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
   $view_display = $storage->load('media.av_portal_photo.oe_theme_main_content');
   $view_content = $view_display->get('content');

--- a/modules/oe_theme_helper/oe_theme_helper.install
+++ b/modules/oe_theme_helper/oe_theme_helper.install
@@ -41,3 +41,20 @@ function oe_theme_helper_update_8001(): ?MarkupInterface {
 
   return NULL;
 }
+
+/**
+ * Update AV Photo media display configuration.
+ */
+function oe_theme_helper_update_8001() {
+  $storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
+  $view_display = $storage->load('media.av_portal_photo.oe_theme_main_content');
+  $view_content = $view_display->get('content');
+  if (isset($view_content['oe_media_avportal_photo'])) {
+    $view_content['oe_media_avportal_photo']['type'] = 'avportal_photo_responsive';
+    $view_content['oe_media_avportal_photo']['settings'] = [
+      'responsive_image_style' => 'oe_theme_main_content',
+    ];
+  }
+  $view_display->set('content', $view_content);
+  $view_display->save();
+}


### PR DESCRIPTION
## OPENEUROPA-1775

### Description

Add responsive image field formatter and use it on the AV photo media.

### Change log

- Added:
- Changed: Updated the AV Photo media display
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

