### PR TITLE
OPENEUROPA-1807: Make sure that moderation block is always right below the tabs - part 2

### DIFF
--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -13,7 +13,7 @@ use Drupal\Core\Entity\EntityInterface;
 /**
  * Implements hook_entity_view_alter().
  */
-function oe_theme_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+function oe_theme_helper_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
   if (!isset($build['content_moderation_control'])) {
     return;
   }


### PR DESCRIPTION
We added the wrong module hook name in the previous PR https://github.com/openeuropa/oe_theme/pull/217/files#diff-3ae0518786005d63057fd2a74049f338R16