### PR TITLE
OPENEUROPA-1892: Add ecl classes to block titles.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -846,3 +846,17 @@ function oe_theme_preprocess_responsive_image_formatter(&$variables) {
   $variables['responsive_image']['#attributes']['class'][] = 'ecl-image';
   $variables['responsive_image']['#attributes']['class'][] = 'ecl-image--fluid';
 }
+
+/**
+ * Implements template_preprocess_preprocess_block().
+ *
+ * For preprocessing default mode of document media type.
+ */
+function oe_theme_preprocess_block(&$variables) {
+  $variables['title_attributes'] += [
+    'class' => [
+      'ecl-heading',
+      'ecl-heading--h2',
+    ],
+  ];
+}

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -853,10 +853,10 @@ function oe_theme_preprocess_responsive_image_formatter(&$variables) {
  * For preprocessing default mode of document media type.
  */
 function oe_theme_preprocess_block(&$variables) {
-  $variables['title_attributes'] += [
+  $variables['title_attributes'] = array_merge_recursive($variables['title_attributes'], [
     'class' => [
       'ecl-heading',
       'ecl-heading--h2',
     ],
-  ];
+  ]);
 }

--- a/tests/Kernel/BlockTest.php
+++ b/tests/Kernel/BlockTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\Kernel;
+
+use Drupal\block_content\Entity\BlockContent;
+use Drupal\block_content\Entity\BlockContentType;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\Tests\block\Traits\BlockCreationTrait;
+use Drupal\Tests\oe_theme\Traits\RenderTrait;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Class BlockTest.
+ */
+class BlockTest extends EntityKernelTestBase {
+
+  use RenderTrait;
+  use BlockCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'user',
+    'block',
+    'block_content',
+    'image',
+    'breakpoint',
+    'responsive_image',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('block_content');
+
+    $this->installConfig([
+      'system',
+      'image',
+      'responsive_image',
+      'block_content',
+    ]);
+
+    $this->container->get('theme_installer')->install(['oe_theme']);
+    $this->container->get('theme_handler')->setDefault('oe_theme');
+    $this->container->set('theme.registry', NULL);
+
+  }
+
+  /**
+   * Test that block titles use appropriate ECL headings.
+   *
+   * @throws \Exception
+   */
+  public function testBlockTitles(): void {
+    // Create a block content type.
+    $block_content_type = BlockContentType::create([
+      'id' => 'test_block_type',
+      'label' => 'Test block type',
+      'description' => "Provides a test block type",
+    ]);
+    $block_content_type->save();
+    block_content_add_body_field($block_content_type->id());
+
+    // And a block content entity.
+    $block_content = BlockContent::create([
+      'info' => 'Test block',
+      'type' => 'test_block_type',
+      'body' => [
+        'value' => 'Test body.',
+        'format' => 'plain_text',
+      ],
+    ]);
+    $block_content->save();
+    $block = $this->placeBlock('block_content:' . $block_content->uuid());
+    $build = $this->container->get('entity.manager')->getViewBuilder('block')->view($block, 'block');
+
+    $html = $this->renderRoot($build);
+
+    $crawler = new Crawler($html);
+
+    // Assert block title contains ECL classes.
+    $actual = $crawler->filter('h2.ecl-heading--h2');
+    $this->assertCount(1, $actual);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-1892

### Description

Add ecl classes to block titles.
### Change log

- Added: Add ecl classes to block titles.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

