### PR TITLE
OPENEUROPA-1978: Add message library.

### DIFF
--- a/js/message.js
+++ b/js/message.js
@@ -1,0 +1,15 @@
+/**
+ * @file
+ * ECL message behavior.
+ */
+(function (ECL, Drupal) {
+  Drupal.behaviors.eclMessage = {
+    attach: function attach() {
+      var messageElements = document.querySelectorAll("[data-ecl-message]");
+      messageElements.forEach((messageElement) => {
+        var message = new ECL.Message(messageElement);
+        message.init();
+      });
+    }
+  };
+})(ECL, Drupal);

--- a/oe_theme.libraries.yml
+++ b/oe_theme.libraries.yml
@@ -12,6 +12,12 @@ accordions:
   dependencies:
     - core/drupal
     - oe_theme/base
+message:
+  js:
+    js/message.js: {}
+  dependencies:
+    - core/drupal
+    - oe_theme/base
 dialogs:
   js:
     js/dialogs.js: {}

--- a/templates/status/status-messages.html.twig
+++ b/templates/status/status-messages.html.twig
@@ -17,6 +17,7 @@
   {% set extra_attributes = extra_attributes|merge([{'name': name, 'value': value}]) %}
 {% endfor %}
 
+{{ attach_library('oe_theme/message') }}
 {# Icons are missing, they should be handled within the ECL component. #}
 {# @todo: open a follow up on INNO board. #}
 {% for type, messages in message_list %}


### PR DESCRIPTION
## OPENEUROPA-1978
### Description

Status messages can't be closed, add required js libraries to fix it.

### Change log

- Added: Message js library.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

