### PR TITLE
OPENEUROPA-1975: Upgrade blockquote to ECL2.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -69,6 +69,7 @@ pipeline:
       # - ./vendor/bin/phpunit
       # @todo: Manually add tests to run until port to ECL 2.0 is completed.
       - ./vendor/bin/phpunit --filter StatusMessagesTest
+      - ./vendor/bin/phpunit --filter ParagraphsTest::testQuote
       - ./vendor/bin/phpunit --filter RenderingTest::testRendering
 
   behat:

--- a/templates/patterns/blockquote/pattern-blockquote.html.twig
+++ b/templates/patterns/blockquote/pattern-blockquote.html.twig
@@ -4,7 +4,7 @@
  * Link block.
  */
 #}
-{% include '@ecl/ec-component-blockquote' with {
+{% include '@ecl/blockquote' with {
   'author': author,
-  'body': body,
+  'citation': body,
 } %}

--- a/tests/Kernel/Paragraphs/ParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/ParagraphsTest.php
@@ -131,10 +131,10 @@ class ParagraphsTest extends ParagraphsTestBase {
 
     $crawler = new Crawler($html);
 
-    $actual = $crawler->filter('blockquote .ecl-blockquote__body')->html();
+    $actual = $crawler->filter('blockquote.ecl-blockquote .ecl-blockquote__body')->html();
     $this->assertEquals($expected['body'], trim($actual));
 
-    $actual = $crawler->filter('blockquote footer.ecl-blockquote__author cite')->text();
+    $actual = $crawler->filter('blockquote.ecl-blockquote footer.ecl-blockquote__attribution cite.ecl-blockquote__author')->text();
     $this->assertEquals($expected['attribution'], trim($actual));
   }
 

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -701,16 +701,16 @@
 #      '.ecl-link-block__list .ecl-link-block__item:nth-child(1)': "Link 1"
 #      '.ecl-link-block__list .ecl-link-block__item:nth-child(2)': "Link 2"
 #      '.ecl-link-block__list .ecl-link-block__item:nth-child(3)': "Link 3"
-#- array:
-#    '#type': pattern
-#    '#id': blockquote
-#    '#fields':
-#      body: "Quote text"
-#      author: "Quote author"
-#  assertions:
-#    equals:
-#      '.ecl-blockquote__author': "― Quote author"
-#      '.ecl-blockquote__body': "Quote text"
+- array:
+    '#type': pattern
+    '#id': blockquote
+    '#fields':
+      body: "Quote text"
+      author: "Quote author"
+  assertions:
+    equals:
+      '.ecl-blockquote__author': "Quote author"
+      '.ecl-blockquote__body': "Quote text"
 #- array:
 #    '#type': pattern
 #    '#id': context_nav


### PR DESCRIPTION
## OPENEUROPA-1975

### Description

Upgrade blockquote to ECL2.

### Change log

- Added: Tests.
- Changed: The pattern of blockquote.
