### PR TITLE
OPENEUROPA-1976: ECL2: Update pager to ECL 2.0.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -73,6 +73,7 @@ pipeline:
       - ./vendor/bin/phpunit --filter RenderingTest::testRendering
       - ./vendor/bin/phpunit --filter SearchFormBlockTest
       - ./vendor/bin/phpunit --filter StatusMessagesTest
+      - ./vendor/bin/phpunit --filter PagerTest
 
   behat:
     group: test

--- a/modules/oe_theme_helper/src/Plugin/PageHeaderMetadata/EntityCanonicalRoutePage.php
+++ b/modules/oe_theme_helper/src/Plugin/PageHeaderMetadata/EntityCanonicalRoutePage.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   label = @Translation("Default entity metadata extractor")
  * )
  *
- * @deprecated in 1.x, will be removed in 2.0.
+ * @todo: This is deprecated in 1.x, will be removed in 2.0.
  */
 class EntityCanonicalRoutePage extends PageHeaderMetadataPluginBase implements ContainerFactoryPluginInterface {
 

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -320,104 +320,115 @@ function oe_theme_preprocess_field(&$variables, $hook): void {
  * Most of the bare-bones are copy-pasted from the Drupal implementation.
  */
 function oe_theme_preprocess_pager(array &$variables): void {
-  $element = $variables['pager']['#element'];
-  $parameters = $variables['pager']['#parameters'];
-  $route_name = $variables['pager']['#route_name'];
-  $route_parameters = $variables['pager']['#route_parameters'] ?? [];
-  global $pager_page_array, $pager_total;
+  // Get the tags for the first, previous, next and last links.
+  $tags = $variables['pager']['#tags'];
 
-  // Nothing to do if there is only one page.
-  if ($pager_total[$element] <= 1) {
-    return;
-  }
+  $variables['ecl_items'] = [];
 
-  $quantity = 5;
-  $pager_middle = ceil($quantity / 2);
-  $pager_current = $pager_page_array[$element] + 1;
-  $pager_first = $pager_current - $pager_middle + 1;
-  $pager_last = $pager_current + $quantity - $pager_middle;
-  $pager_max = $pager_total[$element];
-
-  $i = $pager_first;
-  // Compared to the core implementation, we don't re-center but we cut out the
-  // extra elements from the start and end of the query.
-  if ($pager_last > $pager_max) {
-    $pager_last = $pager_max;
-  }
-  if ($i <= 0) {
-    $i = 1;
-  }
-
-  // Create the "first" and "previous" links if we are not on the first page.
-  if ($pager_page_array[$element] > 0) {
-    $variables['items']['first'] = [];
-    $options = [
-      'query' => pager_query_add_page($parameters, $element, 0),
+  // Generate fist link if it is available.
+  if (!empty($variables['items']['first']['href'])) {
+    $first_link = [];
+    $first_link['type'] = 'first';
+    $first_link['aria_label'] = t('Go to first page');
+    $label = t('‹‹ First');
+    if (isset($tags[0])) {
+      $label = $tags[0];
+    }
+    $first_link['link']['link'] = [
+      'path' => $variables['items']['first']['href'],
+      'label' => $label,
     ];
-    $variables['items']['first']['href'] = \Drupal::url($route_name, $route_parameters, $options);
-    $variables['items']['first']['text'] = '1';
-    $variables['items']['first']['title'] = t('Go to page 1');
-
-    $variables['items']['previous'] = [];
-    $options = [
-      'query' => pager_query_add_page($parameters, $element, $pager_page_array[$element] - 1),
-    ];
-    $variables['items']['previous']['href'] = \Drupal::url($route_name, $route_parameters, $options);
-    $variables['items']['previous']['text'] = t('‹ Previous');
-    $variables['items']['previous']['title'] = t('Go to previous page');
+    $variables['ecl_items'][] = $first_link;
   }
 
-  if ($i != $pager_max) {
-    // Generate the actual pager piece.
-    $variables['items']['pages'] = [];
-    for (; $i <= $pager_last && $i <= $pager_max; $i++) {
-      // Don't generate a link to the first page when the "first" link is
-      // already available.
-      if ($i == 1 && $pager_current > 1) {
+  // Generate previous link if it is available.
+  if (!empty($variables['items']['previous']['href'])) {
+    $previous_link = [];
+    $previous_link['type'] = 'previous';
+    $previous_link['aria_label'] = t('Go to previous page');
+    $label = t('‹ Previous');
+    if (isset($tags[0])) {
+      $label = $tags[0];
+    }
+    $previous_link['link']['link'] = [
+      'path' => $variables['items']['previous']['href'],
+      'label' => $label,
+    ];
+    $variables['ecl_items'][] = $previous_link;
+  }
+
+  // Generate previous ellipses if needed.
+  if (isset($variables['ellipses']['previous']) && $variables['ellipses']['previous']) {
+    $ellipsis = [
+      'type' => 'ellipsis',
+      'label' => '...',
+    ];
+    $variables['ecl_items'][] = $ellipsis;
+  }
+
+  // Generate actual pager items.
+  if (!empty($variables['items']['pages'])) {
+    foreach ($variables['items']['pages'] as $page_key => $page_item) {
+      if ($page_key == $variables['current']) {
+        $current_link = [
+          'type' => 'current',
+          'aria_label' => t('Page @number', ['@number' => $page_key]),
+          'label' => (string) $page_key,
+        ];
+        $variables['ecl_items'][] = $current_link;
         continue;
       }
-
-      // Don't generate a link to the last page when the "last" link is
-      // already available.
-      if ($i == $pager_max && ($pager_current < $pager_max)) {
-        continue;
-      }
-
-      $options = [
-        'query' => pager_query_add_page($parameters, $element, $i - 1),
+      $link = [];
+      $link['aria_label'] = t('Go to page @number', ['@number' => $page_key]);
+      $link['link']['link'] = [
+        'path' => $page_item['href'],
+        'label' => (string) $page_key,
       ];
-      $variables['items']['pages'][$i]['href'] = \Drupal::url($route_name, $route_parameters, $options);
-      if ($i == $pager_current) {
-        $variables['current'] = $i;
-      }
-      $variables['items']['pages'][$i]['text'] = (string) $i;
-      $variables['items']['pages'][$i]['title'] = t('Go to page @number', ['@number' => $i]);
+      $variables['ecl_items'][] = $link;
     }
   }
 
-  // Create the "next" and "last" links if we are not on the last page.
-  if ($pager_page_array[$element] < ($pager_max - 1)) {
-    // Setting up variables for the next page link.
-    $variables['items']['next'] = [];
-    $options = [
-      'query' => pager_query_add_page($parameters, $element, $pager_page_array[$element] + 1),
+  // Generate next ellipses if needed.
+  if (isset($variables['ellipses']['next']) && $variables['ellipses']['next']) {
+    $ellipsis = [
+      'type' => 'ellipsis',
+      'label' => '...',
     ];
-    $variables['items']['next']['href'] = \Drupal::url($route_name, $route_parameters, $options);
-    $variables['items']['next']['text'] = t('Next ›');
-    $variables['items']['next']['title'] = t('Go to next page');
-
-    // Setting up the variables for the last page link.
-    $variables['items']['last'] = [];
-    $options = [
-      'query' => pager_query_add_page($parameters, $element, $pager_max - 1),
-    ];
-    $variables['items']['last']['href'] = \Drupal::url($route_name, $route_parameters, $options);
-    $variables['items']['last']['text'] = (string) $pager_total[$element];
-    $variables['items']['last']['title'] = t('Go to page @number', ['@number' => $pager_total[$element]]);
+    $variables['ecl_items'][] = $ellipsis;
   }
 
-  // Set up additional variables.
-  $variables['max_page'] = $pager_total[$element];
+  // Generate next link if it is available.
+  if (!empty($variables['items']['next']['href'])) {
+    $first_link = [];
+    $first_link['type'] = 'next';
+    $first_link['aria_label'] = t('Go to next page');
+    $label = t('Next ›');
+    if (isset($tags[0])) {
+      $label = $tags[0];
+    }
+    $first_link['link']['link'] = [
+      'path' => $variables['items']['next']['href'],
+      'label' => $label,
+    ];
+    $variables['ecl_items'][] = $first_link;
+  }
+
+  // Generate previous link if it is available.
+  if (!empty($variables['items']['last']['href'])) {
+    $last_link = [];
+    $last_link['type'] = 'last';
+    $last_link['aria_label'] = t('Go to last page');
+    $label = t('Last ››');
+    if (isset($tags[0])) {
+      $label = $tags[0];
+    }
+    $last_link['link']['link'] = [
+      'path' => $variables['items']['last']['href'],
+      'label' => $label,
+    ];
+    $variables['ecl_items'][] = $last_link;
+  }
+
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -347,8 +347,8 @@ function oe_theme_preprocess_pager(array &$variables): void {
     $previous_link['type'] = 'previous';
     $previous_link['aria_label'] = t('Go to previous page');
     $label = t('‹ Previous');
-    if (isset($tags[0])) {
-      $label = $tags[0];
+    if (isset($tags[1])) {
+      $label = $tags[1];
     }
     $previous_link['link']['link'] = [
       'path' => $variables['items']['previous']['href'],
@@ -403,8 +403,8 @@ function oe_theme_preprocess_pager(array &$variables): void {
     $first_link['type'] = 'next';
     $first_link['aria_label'] = t('Go to next page');
     $label = t('Next ›');
-    if (isset($tags[0])) {
-      $label = $tags[0];
+    if (isset($tags[3])) {
+      $label = $tags[3];
     }
     $first_link['link']['link'] = [
       'path' => $variables['items']['next']['href'],
@@ -419,8 +419,8 @@ function oe_theme_preprocess_pager(array &$variables): void {
     $last_link['type'] = 'last';
     $last_link['aria_label'] = t('Go to last page');
     $label = t('Last ››');
-    if (isset($tags[0])) {
-      $label = $tags[0];
+    if (isset($tags[4])) {
+      $label = $tags[4];
     }
     $last_link['link']['link'] = [
       'path' => $variables['items']['last']['href'],

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -24,14 +24,7 @@
  */
 #}
 {% if items %}
-  {% include '@ecl/ec-component-pager' with {
-    'current_page': current,
-    'pages': items.pages,
-    'first': items.first,
-    'previous': items.previous,
-    'next': items.next,
-    'last': items.last,
-    'max_page': max_page,
-    'label_page': 'Page'|t,
+  {% include '@ecl/pagination' with {
+    'items': ecl_items,
   } %}
 {% endif %}


### PR DESCRIPTION
## OPENEUROPA-1976

### Description

Update pagination to ECL 2.0

### Change log

- Added:
- Changed: Update pagination to ECL 2.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

