### PR TITLE
OPENEUROPA-1775: Fixing upgrade path of entity view display.

### DIFF
--- a/modules/oe_theme_helper/oe_theme_helper.install
+++ b/modules/oe_theme_helper/oe_theme_helper.install
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\block\Entity\Block;
 use Drupal\Component\Render\MarkupInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 
 /**
  * Show the page header block on the homepage.
@@ -48,6 +49,11 @@ function oe_theme_helper_update_8001(): ?MarkupInterface {
 function oe_theme_helper_update_8002() {
   $storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
   $view_display = $storage->load('media.av_portal_photo.oe_theme_main_content');
+  if (!$view_display instanceof EntityViewDisplayInterface) {
+    // If there is no display, it means it was not imported so we do nothing.
+    return;
+  }
+
   $view_content = $view_display->get('content');
   if (isset($view_content['oe_media_avportal_photo'])) {
     $view_content['oe_media_avportal_photo']['type'] = 'avportal_photo_responsive';


### PR DESCRIPTION
This PR fixes the update hook introduced here: https://github.com/openeuropa/oe_theme/commit/eb0fc669e4665329b06c0122ce09fc8455016957

The problem was the assumption on the existence of the entity view display when in fact it was optional.