### PR TITLE
OPENEUROPA-1991: Update social media to ECL2.0.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -21,7 +21,10 @@ use Drupal\oe_theme\ValueObject\GalleryItemValueObject;
 function oe_theme_preprocess(&$variables) {
   global $base_url;
   $theme = \Drupal::theme()->getActiveTheme();
-  $variables['ecl_icon_path'] = $base_url . '/' . $theme->getPath() . '/dist/images/icons/sprites/icons.svg';
+  $variables['ecl_images_path'] = $base_url . '/' . $theme->getPath() . '/dist/images';
+  $variables['ecl_icon_path'] = $variables['ecl_images_path'] . '/icons/sprites/icons.svg';
+  $variables['ecl_logo_path'] = $variables['ecl_images_path'] . '/logo';
+  $variables['ecl_social_icon_path'] = $variables['ecl_images_path'] . '/social-icons/sprites/icons-social.svg';
 }
 
 /**
@@ -708,10 +711,21 @@ function oe_theme_preprocess_pattern_link_block(array &$variables): void {
 function _oe_theme_preprocess_pattern_social_media_links(array &$variables): void {
   // Format social media links in order to respect ECL expectations.
   foreach ($variables['links'] as $key => $link) {
-    $variables['links'][$key]['variant'] = $link['service'];
-    $variables['links'][$key]['link'] = [
-      'label' => $link['label'],
-      'href' => $link['url'],
+    $variables['links'][$key]['path'] = $link['url'];
+    $variables['links'][$key]['icon_position'] = 'before';
+    $variables['links'][$key]['icon'] = [
+      [
+        'path' => $variables['ecl_social_icon_path'],
+        'name' => $link['service'],
+        'size' => 'xl',
+        'extra_classes' => 'ecl-social-media-follow__icon',
+      ],
+      [
+        'path' => $variables['ecl_social_icon_path'],
+        'name' => $link['service'] . '_hover',
+        'size' => 'xl',
+        'extra_classes' => 'ecl-social-media-follow__icon-hover',
+      ],
     ];
   }
 }

--- a/templates/patterns/social_media_links/pattern-social-media-links-horizontal.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links-horizontal.html.twig
@@ -5,12 +5,7 @@
  */
 #}
 {# @todo: Termorarily disable more link, fix this. #}
-{% include '@ecl/ec-component-social-media-link' with {
-  'variant': 'horizontal',
-  'text': title,
-  'social_icons': links,
-  'more': {
-    'label': '',
-    'href': '',
-  }
+{% include '@ecl/social-media-follow' with {
+  'description': title,
+  'links': links,
 } %}

--- a/templates/patterns/social_media_links/pattern-social-media-links-vertical.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links-vertical.html.twig
@@ -5,11 +5,8 @@
  */
 #}
 {# @todo: Termorarily disable more link, fix this. #}
-{% include '@ecl/ec-component-social-media-link' with {
-  'text': title,
-  'social_icons': links,
-  'more': {
-    'label': '',
-    'href': '',
-  }
+{% include '@ecl/social-media-follow' with {
+  'variant': 'vertical',
+  'description': title,
+  'links': links,
 } %}

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -893,56 +893,57 @@
   assertions:
     equals:
       'button.ecl-button--splash-page': "Button label"
-#- array:
-#    '#type': pattern
-#    '#id': social_media_links_vertical
-#    '#fields':
-#      title: "View European Commission on:"
-#      links:
-#        - service: "facebook"
-#          label: "Facebook"
-#          url: "http://facebook.com"
-#        - service: "twitter"
-#          label: "Twitter"
-#          url: "http://twitter.com"
-#        - service: "instagram"
-#          label: "Instagram"
-#          url: "http://instagram.com"
-#  assertions:
-#    count:
-#      'a.ecl-social-icon--facebook[href="http://facebook.com"]': 1
-#      'a.ecl-social-icon--instagram[href="http://instagram.com"]': 1
-#      'a.ecl-social-icon--twitter[href="http://twitter.com"]': 1
-#    equals:
-#      '.ecl-social-media-link > p.ecl-paragraph': "View European Commission on:"
-#      'a.ecl-social-icon--facebook': "Facebook"
-#      'a.ecl-social-icon--twitter': "Twitter"
-#      'a.ecl-social-icon--instagram': "Instagram"
-#- array:
-#    '#type': pattern
-#    '#id': social_media_links_horizontal
-#    '#fields':
-#      title: "View European Commission on:"
-#      links:
-#        - service: "facebook"
-#          label: "Facebook"
-#          url: "http://facebook.com"
-#        - service: "twitter"
-#          label: "Twitter"
-#          url: "http://twitter.com"
-#        - service: "instagram"
-#          label: "Instagram"
-#          url: "http://instagram.com"
-#  assertions:
-#    count:
-#      'a.ecl-social-icon--facebook[href="http://facebook.com"]': 1
-#      'a.ecl-social-icon--instagram[href="http://instagram.com"]': 1
-#      'a.ecl-social-icon--twitter[href="http://twitter.com"]': 1
-#    equals:
-#      '.ecl-social-media-link--horizontal > p.ecl-paragraph': "View European Commission on:"
-#      'a.ecl-social-icon--facebook': "Facebook"
-#      'a.ecl-social-icon--twitter': "Twitter"
-#      'a.ecl-social-icon--instagram': "Instagram"
+- array:
+    '#type': pattern
+    '#id': social_media_links_vertical
+    '#fields':
+      title: "View European Commission on:"
+      links:
+        - service: "facebook"
+          label: "Facebook"
+          url: "http://facebook.com"
+        - service: "twitter"
+          label: "Twitter"
+          url: "http://twitter.com"
+        - service: "instagram"
+          label: "Instagram"
+          url: "http://instagram.com"
+  assertions:
+    count:
+      'a.ecl-social-media-follow__link[href="http://facebook.com"]': 1
+      'a.ecl-social-media-follow__link[href="http://instagram.com"]': 1
+      'a.ecl-social-media-follow__link[href="http://twitter.com"]': 1
+    equals:
+      '.ecl-social-media-follow--vertical > p.ecl-social-media-follow__description': "View European Commission on:"
+      'a.ecl-social-media-follow__link[href="http://facebook.com"] span': "Facebook"
+      'a.ecl-social-media-follow__link[href="http://twitter.com"] span': "Twitter"
+      'a.ecl-social-media-follow__link[href="http://instagram.com"] span': "Instagram"
+- array:
+    '#type': pattern
+    '#id': social_media_links_horizontal
+    '#fields':
+      title: "View European Commission on:"
+      links:
+        - service: "facebook"
+          label: "Facebook"
+          url: "http://facebook.com"
+        - service: "twitter"
+          label: "Twitter"
+          url: "http://twitter.com"
+        - service: "instagram"
+          label: "Instagram"
+          url: "http://instagram.com"
+  assertions:
+    assertions:
+      count:
+        'a.ecl-social-media-follow__link[href="http://facebook.com"]': 1
+        'a.ecl-social-media-follow__link[href="http://instagram.com"]': 1
+        'a.ecl-social-media-follow__link[href="http://twitter.com"]': 1
+      equals:
+        '.ecl-social-media-follow > p.ecl-social-media-follow__description': "View European Commission on:"
+        'a.ecl-social-media-follow__link[href="http://facebook.com"] span': "Facebook"
+        'a.ecl-social-media-follow__link[href="http://twitter.com"] span': "Twitter"
+        'a.ecl-social-media-follow__link[href="http://instagram.com"] span': "Instagram"
 #- array:
 #    '#type': pattern
 #    '#id': social_icon


### PR DESCRIPTION
## OPENEUROPA-1991
### Description

Update social media links to ECL 2.0

### Change log

- Added:
- Changed: Update social media links to ECL 2.0
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

