### PR TITLE
OPENEUROPA-1996: Search box too small

### DIFF
--- a/templates/form/form--oe-search-search-form.html.twig
+++ b/templates/form/form--oe-search-search-form.html.twig
@@ -10,9 +10,9 @@
  */
 #}
 
-<form {{ attributes.addClass(['ecl-search-form', 'ecl-search-form--']) }}>
+<form {{ attributes.addClass(['ecl-search-form', 'ecl-site-header__search']) }}>
   <label class="ecl-search-form__textfield-wrapper">
-    <span class="ecl-u-sr-only">{{ "Search this website" }}</span>
+    <span class="ecl-u-sr-only">{{ "Search this website"|t }}</span>
     {% include '@ecl/generic-component-form-text-input' with {
       'id': 'search',
       'type': 'search',

--- a/tests/Kernel/SearchFormBlockTest.php
+++ b/tests/Kernel/SearchFormBlockTest.php
@@ -38,7 +38,7 @@ class SearchFormBlockTest extends AbstractKernelTestBase {
     $crawler = new Crawler($html);
 
     // Make sure that search form block is present.
-    $actual = $crawler->filter('form.ecl-search-form.ecl-search-form--');
+    $actual = $crawler->filter('form.ecl-search-form.ecl-site-header__search');
     $this->assertCount(1, $actual);
     // Make sure that search form block rendered correctly.
     $actual = $crawler->filter('input.ecl-text-input.ecl-search-form__textfield');


### PR DESCRIPTION
## OPENEUROPA-1996

### Description

Fix the template of Search box in the header.

### Change log

- Changed: Fix a typo on the template.
