### PR TITLE
OPENEUROPA-2012: ECL2: Add Identity on the page header.

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -58,7 +58,7 @@ default:
         navigation: ".ecl-navigation-menu"
         page: "body"
         page header: ".ecl-page-header"
-        page header site identity: ".ecl-page-header .ecl-page-header__identity"
+        page header site identity: "h2.ecl-u-type-heading-2"
         page header title: ".ecl-page-header .ecl-page-header__title"
         page header intro: ".ecl-page-header .ecl-page-header__description"
         page header meta: ".ecl-page-header .ecl-page-header__meta-list"

--- a/modules/oe_theme_helper/src/Plugin/Block/PageHeaderBlock.php
+++ b/modules/oe_theme_helper/src/Plugin/Block/PageHeaderBlock.php
@@ -112,6 +112,7 @@ class PageHeaderBlock extends BlockBase implements ContainerFactoryPluginInterfa
       '#metas' => $metadata['metas'] ?? [],
       '#infos' => $metadata['infos'] ?? [],
     ];
+
     return $this->addBreadcrumbSegments($build, $title);
   }
 

--- a/templates/patterns/page_header/pattern-page-header.html.twig
+++ b/templates/patterns/page_header/pattern-page-header.html.twig
@@ -41,7 +41,7 @@
   {% set _infos = _infos|merge([_info]) %}
 {% endfor %}
 
-{% if identity != '' %}
+{% if identity is not empty %}
   <div class="ecl-u-bg-blue ecl-u-pv-2xs">
     <div class="ecl-container ">
       <h2 class="ecl-u-color-white ecl-u-type-heading-2">{{ identity }}</h2>

--- a/templates/patterns/page_header/pattern-page-header.html.twig
+++ b/templates/patterns/page_header/pattern-page-header.html.twig
@@ -41,6 +41,14 @@
   {% set _infos = _infos|merge([_info]) %}
 {% endfor %}
 
+{% if identity != '' %}
+  <div class="ecl-u-bg-blue ecl-u-pv-2xs">
+    <div class="ecl-container ">
+      <h2 class="ecl-u-color-white ecl-u-type-heading-2">{{ identity }}</h2>
+    </div>
+  </div>
+{% endif %}
+
 {% include '@ecl/page-header' with {
   'title': title,
   'description': introduction,

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -623,8 +623,7 @@
       '.ecl-page-header__info-list': 1
       '.ecl-page-header__info-item': 2
     equals:
-      # @todo: Add this following test when identity is on ecl2.
-      #'.ecl-page-header__identity': "Digital single market"
+      'h2.ecl-u-type-heading-2': "Digital single market"
       'h1.ecl-page-header__title': "Business, Economy, Euro"
       '.ecl-page-header__description': "EU economy, finance and the euro, and practical information for EU businesses and entrepreneurs on product safety, environmental regulations, trade with non-EU countries and competition rules."
       '.ecl-page-header__meta-list': "News article | 6 July 2015 | Brussels"

--- a/tests/features/page-header.feature
+++ b/tests/features/page-header.feature
@@ -28,7 +28,7 @@ Feature: Page header block component.
     Given I am an anonymous user
     When I am on "the user registration page"
     Then I should see the heading "Create new account" in the "page header"
-    Then I should not see the "page header site identity" element in the "page"
+    And I should not see the "page header site identity" element in the "page"
     And the breadcrumb trail should be "Home"
     And the breadcrumb active element should be "Create new account"
 


### PR DESCRIPTION
## OPENEUROPA-2012

### Description

Add Identity on the page header.

### Change log

- Added:
- Changed: Add identity site on page header pattern.
- Deprecated:
- Removed:
- Fixed:
- Security:
