### PR TITLE
OPENEUROPA-2054: Use phpcs exclude parameter to avoid deprecated error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "drupal/core": "^8.7",
         "drupal/ui_patterns": "^1.0",
-        "openeuropa/ecl-twig-loader": "~0.1",
+        "openeuropa/ecl-twig-loader": "dev-OPENEUROPA-2054",
         "php": "^7.1"
     },
     "require-dev": {
@@ -25,7 +25,7 @@
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",
-        "openeuropa/code-review": "~1.0@beta",
+        "openeuropa/code-review": "dev-OPENEUROPA-2054",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/oe_content": "~1.0",
         "openeuropa/oe_corporate_blocks": "~1.0",

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -11,12 +11,14 @@ parameters:
     - inc
     - theme
     - install
+  tasks.phpcs.exclude:
+    - Drupal.Commenting.Deprecated
 
   extra_tasks:
     phpparser:
-      ignore_patterns: %tasks.phpcs.ignore_patterns%
+      ignore_patterns: '%tasks.phpcs.ignore_patterns%'
       visitors:
         declare_strict_types: ~
-      triggered_by: %tasks.phpcs.triggered_by%
+      triggered_by: '%tasks.phpcs.triggered_by%'
   extensions:
     - OpenEuropa\CodeReview\ExtraTasksExtension

--- a/modules/oe_theme_helper/src/Plugin/PageHeaderMetadata/EntityCanonicalRoutePage.php
+++ b/modules/oe_theme_helper/src/Plugin/PageHeaderMetadata/EntityCanonicalRoutePage.php
@@ -18,9 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   id = "entity_canonical_route",
  *   label = @Translation("Default entity metadata extractor")
  * )
- * phpcs:disable Drupal.Commenting.Deprecated
+ *
  * @deprecated in 1.1.x and is removed from 2.0.0.
- * phpcs:enable Drupal.Commenting.Deprecated
  */
 class EntityCanonicalRoutePage extends PageHeaderMetadataPluginBase implements ContainerFactoryPluginInterface {
 


### PR DESCRIPTION
## OPENEUROPA-2054

### Description

Use phpcs exclude parameter to avoid deprecated error.

### Change log

- Changed: code-review and ecl-twig-loader versions.
- Added: exclude rule for phpcs for deprecated.
- Deprecated: incode phpcs ignore comments.

