### PR TITLE
OPENEUROPA-2082: Change 'Related links' field label to h2.

### DIFF
--- a/templates/field/field--oe-related-links.html.twig
+++ b/templates/field/field--oe-related-links.html.twig
@@ -1,4 +1,4 @@
-<h3 class="ecl-heading ecl-heading--h3">{{ 'Related links'|t }}</h3>
+<h2 class="ecl-heading ecl-heading--h2">{{ 'Related links'|t }}</h2>
 <ul class="ecl-list--unstyled">
   {% for item in items %}
     {{ item.content }}

--- a/tests/Kernel/ContentRenderTest.php
+++ b/tests/Kernel/ContentRenderTest.php
@@ -145,7 +145,7 @@ class ContentRenderTest extends AbstractKernelTestBase {
     $this->assertContains('Body', $body_wrapper->text());
 
     // Related links.
-    $related_links_heading = $crawler->filter('.ecl-heading--h3');
+    $related_links_heading = $crawler->filter('.ecl-heading--h2');
     $this->assertContains('Related links', $related_links_heading->text());
     $related_links = $crawler->filter('.ecl-list--unstyled .ecl-list-item__link');
     $this->assertCount(2, $related_links);
@@ -191,7 +191,7 @@ class ContentRenderTest extends AbstractKernelTestBase {
     $this->assertContains('Body', $body_wrapper->text());
 
     // Related links.
-    $related_links_heading = $crawler->filter('.ecl-heading--h3');
+    $related_links_heading = $crawler->filter('.ecl-heading--h2');
     $this->assertContains('Related links', $related_links_heading->text());
     $related_links = $crawler->filter('.ecl-list--unstyled .ecl-list-item__link');
     $this->assertCount(2, $related_links);


### PR DESCRIPTION
## OPENEUROPA-2082

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

