### PR TITLE
OPENEUROPA-2135: Add publication date to Publication page header metadata

### DIFF
--- a/modules/oe_theme_content_publication/config/install/core.date_format.oe_theme_publication_date.yml
+++ b/modules/oe_theme_content_publication/config/install/core.date_format.oe_theme_publication_date.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: oe_theme_publication_date
+label: 'Publication date'
+locked: false
+pattern: 'd F Y'

--- a/modules/oe_theme_content_publication/oe_theme_content_publication.post_update.php
+++ b/modules/oe_theme_content_publication/oe_theme_content_publication.post_update.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa theme Publication post updates.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Datetime\Entity\DateFormat;
+
+/**
+ * Add a date format for the Publication page header metadata.
+ */
+function oe_theme_content_publication_post_update_00001_add_publication_date_format(array &$sandbox): void {
+  $date_format_values = [
+    'langcode' => 'en',
+    'status' => TRUE,
+    'dependencies' => [],
+    'id' => 'oe_theme_publication_date',
+    'label' => 'Publication date',
+    'locked' => FALSE,
+    'pattern' => 'd F Y',
+  ];
+  $publication_date_format = DateFormat::create($date_format_values);
+  $publication_date_format->save();
+}

--- a/modules/oe_theme_content_publication/src/Plugin/PageHeaderMetadata/PublicationContentType.php
+++ b/modules/oe_theme_content_publication/src/Plugin/PageHeaderMetadata/PublicationContentType.php
@@ -4,8 +4,15 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme_content_publication\Plugin\PageHeaderMetadata;
 
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\node\NodeInterface;
 use Drupal\oe_theme_helper\Plugin\PageHeaderMetadata\NodeViewRoutesBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Page header metadata for the OpenEuropa Publication content entity.
@@ -17,6 +24,56 @@ use Drupal\oe_theme_helper\Plugin\PageHeaderMetadata\NodeViewRoutesBase;
  * )
  */
 class PublicationContentType extends NodeViewRoutesBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * The date formatter.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
+
+  /**
+   * Creates a new PublicationContentType object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $current_route_match
+   *   The current route match.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   *   The event dispatcher.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
+   *   The date formatter.
+   */
+  public function __construct(array $configuration, string $plugin_id, $plugin_definition, RouteMatchInterface $current_route_match, EntityTypeManagerInterface $entity_type_manager, EntityRepositoryInterface $entity_repository, EventDispatcherInterface $event_dispatcher, DateFormatterInterface $date_formatter) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $current_route_match, $entity_type_manager, $entity_repository, $event_dispatcher);
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): self {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('entity_type.manager'),
+      $container->get('entity.repository'),
+      $container->get('event_dispatcher'),
+      $container->get('date.formatter')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -52,6 +109,11 @@ class PublicationContentType extends NodeViewRoutesBase {
           '#langcode' => $summary->getLangcode(),
         ],
       ],
+    ];
+
+    $timestamp = $entity->get('oe_publication_date')->date->getTimestamp();
+    $metadata['metas'] = [
+      $this->dateFormatter->format($timestamp, 'oe_theme_publication_date'),
     ];
 
     return $metadata;

--- a/tests/Kernel/ContentRenderTest.php
+++ b/tests/Kernel/ContentRenderTest.php
@@ -256,6 +256,7 @@ class ContentRenderTest extends AbstractKernelTestBase {
         ],
       ],
       'oe_summary' => 'Summary',
+      'oe_publication_date' => '2019-04-05',
       'uid' => 0,
       'status' => 1,
     ]);

--- a/tests/features/page-header.feature
+++ b/tests/features/page-header.feature
@@ -78,6 +78,17 @@ Feature: Page header block component.
     # The default text format should be applied, converting URLs into links.
     And I should see the link "http://www.example.org" in the "page header intro"
 
+  Scenario: Publication content type has custom metadata shown in the page header.
+    Given "oe_publication" content:
+      | title          | oe_summary                           | oe_teaser | body    | oe_publication_date | oe_subject                     | oe_author                                                               | oe_content_content_owner                                                |
+      | My publication | http://www.example.org is a web page | My teaser | My body | 2019-04-02          | http://data.europa.eu/uxp/1000 | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH | http://publications.europa.eu/resource/authority/corporate-body/EP_PECH |
+    And I am an anonymous user
+    When I go to the "My publication" page
+    Then I should see the text "http://www.example.org is a web page" in the "page header intro"
+    # The default text format should be applied, converting URLs into links.
+    And I should see the link "http://www.example.org" in the "page header intro"
+    And I should see "02 April 2019" in the "page header meta"
+
   Scenario: The page header block shows the content language switcher.
     Given the following "Spanish" translation for the "Robots are everywhere" demo page:
       | Title | Los robots estan en todas partes |


### PR DESCRIPTION
## OPENEUROPA-2135
### Description

The Publication page header needs to show the publication date.

### Change log

- Added: Publication date to Publication page header metadata.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

