### PR TITLE
OPENEUROPA-1983: Update video banner to ECL2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
         "drupal/core": "^8.7",
         "drupal/ui_patterns": "^1.0",
         "openeuropa/ecl-twig-loader": "dev-master",
-        "php": "^7.1",
-        "ext-fileinfo": "*"
+        "php": "^7.1"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "drupal/core": "^8.7",
         "drupal/ui_patterns": "^1.0",
         "openeuropa/ecl-twig-loader": "dev-master",
-        "php": "^7.1"
+        "php": "^7.1",
+        "ext-fileinfo": "*"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.0",

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -673,10 +673,9 @@ function oe_theme_preprocess_pattern_accordion(array &$variables): void {
  */
 function oe_theme_preprocess_pattern_banner_video(array &$variables): void {
   if (!empty($variables['video']['sources'])) {
-    // We need to rename the variables that the pattern module uses.
+    // We need to rename the variables that the Patterns module uses.
     foreach ($variables['video']['sources'] as &$source) {
-      $source['src'] = $source['source'];
-      $source['type'] = $source['video_type'];
+      $source['type'] = $source['src_type'];
     }
   }
 }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -672,13 +672,12 @@ function oe_theme_preprocess_pattern_accordion(array &$variables): void {
  * Implements hook_preprocess_HOOK().
  */
 function oe_theme_preprocess_pattern_banner_video(array &$variables): void {
-  if (isset($variables['video']['is_iframe']) && !$variables['video']['is_iframe'] && !empty($variables['video']['src'])) {
-    $variables['video']['sources'] = [
-      [
-        'src' => $variables['video']['src'],
-        'type' => mime_content_type($variables['video']['src']),
-      ],
-    ];
+  if (!empty($variables['video']['sources'])) {
+    // We need to rename the variables that the pattern module uses.
+    foreach ($variables['video']['sources'] as &$source) {
+      $source['src'] = $source['source'];
+      $source['type'] = $source['video_type'];
+    }
   }
 }
 

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -671,6 +671,20 @@ function oe_theme_preprocess_pattern_accordion(array &$variables): void {
 /**
  * Implements hook_preprocess_HOOK().
  */
+function oe_theme_preprocess_pattern_banner_video(array &$variables): void {
+  if (isset($variables['video']['is_iframe']) && !$variables['video']['is_iframe'] && !empty($variables['video']['src'])) {
+    $variables['video']['sources'] = [
+      [
+        'src' => $variables['video']['src'],
+        'type' => mime_content_type($variables['video']['src']),
+      ],
+    ];
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function oe_theme_preprocess_pattern_dropdown(array &$variables): void {
   $defaults = [
     'wrapper_id' => 'ecl-button-dropdown',

--- a/templates/patterns/banners/banner_video.ui_patterns.yml
+++ b/templates/patterns/banners/banner_video.ui_patterns.yml
@@ -8,8 +8,7 @@ banner_video:
       description: "Banner video"
       preview:
         src: "https://ec.europa.eu/avservices/play.cfm?ref=I101631"
-        is_iframe: "true"
-        ratio: "16-9"
+        is_iframe: true
         caption: "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit"
     description:
       type: "text"

--- a/templates/patterns/banners/banner_video.ui_patterns.yml
+++ b/templates/patterns/banners/banner_video.ui_patterns.yml
@@ -5,13 +5,16 @@ banner_video:
     video:
       type: "array"
       label: "Video"
-      description: "Banner video"
+      description: "Banner video: uses the media container parameters as defined by the ECL"
       preview:
-        src: "https://ec.europa.eu/avservices/play.cfm?ref=I101631"
-        is_iframe: true
-        caption: "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit"
+        sources:
+          - source: "https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"
+            video_type: "video/mp4"
+        description: "The European Commission has put forward ambitious yet realistic proposals for a modern EU budget. It is time for an EU budget that reflects rapid developments in innovation, the economy, the environment and geopolitics, amongst others."
+        image: "https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"
+        alt: "Jean Monnet banner."
     description:
       type: "text"
       label: "Description"
       description: "Banner description"
-      preview: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation."
+      preview: "The European Commission has put forward ambitious yet realistic proposals for a modern EU budget. It is time for an EU budget that reflects rapid developments in innovation, the economy, the environment and geopolitics, amongst others. The Commission is putting forward modern, clearer and simpler EU financial rules that ensure the EU budget delivers on the issues that matter to Europeans."

--- a/templates/patterns/banners/banner_video.ui_patterns.yml
+++ b/templates/patterns/banners/banner_video.ui_patterns.yml
@@ -8,8 +8,8 @@ banner_video:
       description: "Banner video: uses the media container parameters as defined by the ECL"
       preview:
         sources:
-          - source: "https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"
-            video_type: "video/mp4"
+          - src: "https://defiris.ec.streamcloud.be/findmedia/11/101631/LR_I101631INT1W.mp4?latest=0004553892"
+            src_type: "video/mp4"
         description: "The European Commission has put forward ambitious yet realistic proposals for a modern EU budget. It is time for an EU budget that reflects rapid developments in innovation, the economy, the environment and geopolitics, amongst others."
         image: "https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"
         alt: "Jean Monnet banner."

--- a/templates/patterns/banners/pattern-banner-video.html.twig
+++ b/templates/patterns/banners/pattern-banner-video.html.twig
@@ -33,18 +33,7 @@
     <div class="ecl-container ecl-video-banner__container">
       <div class="ecl-row">
         <div class="ecl-col-sm-12 ecl-col-md-6">
-          {% if _video.is_iframe is defined and _video.is_iframe %}
-            <figure class="ecl-media-container">
-              <iframe class="ecl-media-container__media" src="{{ _video.src }}" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
-              <figcaption class="ecl-media-container__caption">{{ _video.caption }}</figcaption>
-            </figure>
-          {% else %}
-              {% include '@ecl/media-container' with {
-                'sources': _video.sources,
-                'image': _video.image,
-                'description': _video.caption,
-              } %}
-          {% endif %}
+          {% include '@ecl/media-container' with _video %}
         </div>
         <div class="ecl-col-sm-12 ecl-col-md-6">
           <p class="ecl-u-type-paragraph">

--- a/templates/patterns/banners/pattern-banner-video.html.twig
+++ b/templates/patterns/banners/pattern-banner-video.html.twig
@@ -1,11 +1,57 @@
-{#
-/**
- * @file
- * Banner video.
- */
-#}
-{% include '@ecl/ec-component-banner' with {
-  'type': 'video',
-  'video': video,
-  'description': description,
-} %}
+{% spaceless %}
+
+  {#
+  /**
+   * @file
+   * Video banner.
+   */
+  #}
+
+  {# Internal properties #}
+
+  {% set _description = description|default('') %}
+  {% set _video = video|default({}) %}
+
+  {% set _css_class = ['ecl-video-banner']|join(' ') %}
+  {% set _extra_attributes = '' %}
+
+  {# Internal logic - Process properties #}
+
+  {% if extra_classes is defined and extra_classes is not empty %}
+    {% set _css_class = _css_class ~ ' ' ~ extra_classes %}
+  {% endif %}
+
+  {% if extra_attributes is defined and extra_attributes is not empty and extra_attributes is iterable %}
+    {% for attr in extra_attributes %}
+      {% set _extra_attributes = _extra_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value ~ '"' %}
+    {% endfor %}
+  {% endif %}
+
+  {# Print the result #}
+
+  <section class="{{ _css_class }}"{{ _extra_attributes }}>
+    <div class="ecl-container ecl-video-banner__container">
+      <div class="ecl-row">
+        <div class="ecl-col-sm-12 ecl-col-md-6">
+          {% if _video.is_iframe is defined and _video.is_iframe %}
+            <figure class="ecl-media-container">
+              <iframe class="ecl-media-container__media" src="{{ _video.src }}" allowfullscreen="allowfullscreen" scrolling="no"></iframe>
+              <figcaption class="ecl-media-container__caption">{{ _video.caption }}</figcaption>
+            </figure>
+          {% else %}
+              {% include '@ecl/media-container' with {
+                'sources': _video.sources,
+                'image': _video.image,
+                'description': _video.caption,
+              } %}
+          {% endif %}
+        </div>
+        <div class="ecl-col-sm-12 ecl-col-md-6">
+          <p class="ecl-u-type-paragraph">
+            {{ _description }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endspaceless %}

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -165,24 +165,26 @@
       'div.ecl-hero-banner__content h1.ecl-hero-banner__title': Banner title
       'div.ecl-hero-banner__content p.ecl-hero-banner__description': Banner description
       'div.ecl-hero-banner__content a.ecl-hero-banner__link[href="http://example.com"]': Subscribe
-
-#- array:
-#    '#type': pattern
-#    '#id': banner_video
-#    '#fields':
-#      video:
-#        src: "https://ec.europa.eu/avservices/play.cfm?ref=I101631"
-#        is_iframe: "true"
-#        ratio: "16-9"
-#        caption: "Video caption"
-#      description: "<p class=\"ecl-paragraph\">Banner description</p>"
-#  assertions:
-#    count:
-#      'div.ecl-banner--video': 1
-#      'div.ecl-banner--video section.ecl-file--video div.ecl-u-ratio-16-9 iframe[src="https://ec.europa.eu/avservices/play.cfm?ref=I101631"]': 1
-#    equals:
-#      'div.ecl-banner--video section.ecl-file--video div.ecl-file__caption': Video caption
-#      'div.ecl-banner--video div.ecl-col-lg-6 p.ecl-paragraph': "Banner description"
+- array:
+    '#type': pattern
+    '#id': banner_video
+    '#fields':
+      video:
+        description: "Video caption"
+        image: "https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"
+        alt: "Jean Monnet banner."
+        sources:
+          - source: "https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"
+            video_type: "video/mp4"
+      description: "Banner description"
+  assertions:
+    count:
+      'section.ecl-video-banner': 1
+      'video.ecl-media-container__media[alt="Jean Monnet banner."][poster="https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"]': 1
+      'source[src="https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"][type="video/mp4"]': 1
+    equals:
+      'figcaption.ecl-media-container__caption': Video caption
+      'p.ecl-u-type-paragraph': "Banner description"
 - array:
     '#type': pattern
     '#id': file

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -174,14 +174,14 @@
         image: "https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"
         alt: "Jean Monnet banner."
         sources:
-          - source: "https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"
-            video_type: "video/mp4"
+          - src: "https://defiris.ec.streamcloud.be/findmedia/11/101631/LR_I101631INT1W.mp4?latest=0004553892"
+            src_type: "video/mp4"
       description: "Banner description"
   assertions:
     count:
       'section.ecl-video-banner': 1
       'video.ecl-media-container__media[alt="Jean Monnet banner."][poster="https://inno-ecl.s3.amazonaws.com/media/examples/example-image.jpg"]': 1
-      'source[src="https://clips.vorwaerts-gmbh.de/big_buck_bunny.mp4"][type="video/mp4"]': 1
+      'source[src="https://defiris.ec.streamcloud.be/findmedia/11/101631/LR_I101631INT1W.mp4?latest=0004553892"][type="video/mp4"]': 1
     equals:
       'figcaption.ecl-media-container__caption': Video caption
       'p.ecl-u-type-paragraph': "Banner description"


### PR DESCRIPTION
## OPENEUROPA-1983

### Description

Update video banner to ECL 2

### Change log

- Added:
- Changed: Update video banner to ECL 2
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

