### PR TITLE
Allow buttons on hero banners

### DIFF
--- a/templates/patterns/banners/banner_hero.ui_patterns.yml
+++ b/templates/patterns/banners/banner_hero.ui_patterns.yml
@@ -29,6 +29,14 @@ banner_hero:
       label: "Label"
       description: "Hero link label."
       preview: "Subscribe"
+    button:
+      type: "text"
+      label: "Button"
+      description: "Hero button, this will not render the url + label as link"
+      preview:
+        variant: "call"
+        href: "#"
+        label: "European commission"
     description:
       type: "text"
       label: "Description"

--- a/templates/patterns/banners/pattern-banner-hero.html.twig
+++ b/templates/patterns/banners/pattern-banner-hero.html.twig
@@ -5,13 +5,16 @@
  */
 #}
 
-{% set _link = {'link' : {'path' : url, 'label' : label}} %}
+{% if not button %}
+  {% set _link = {'link' : {'path' : url, 'label' : label}} %}
+{% endif %}
 
 {% include '@ecl/hero-banner' with {
   'type': banner_type|e,
   'image': image.src,
   'title': title,
   'link': _link,
+  'button': button,
   'description': description,
   'centered': centered,
 } %}


### PR DESCRIPTION
### Description

The hero banner allows both url with label and buttons, however buttons were not yet part of the implementation in the theme.

### Change log

- Added: Button to the hero banner pattern

