### PR TITLE
OPENEUROPA-2192: Use ECL background image attribute and document image styles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ same between the two libraries.
 * [OpenEuropa Theme Policy](/modules/oe_theme_content_policy/README.md)
 * [OpenEuropa Theme Publication](/modules/oe_theme_content_publication/README.md)
 
+## Image styles
+
+OpenEuropa Theme ships with a number of image styles that should help users follow the guidelines set by the ECL.
+The following is a list of all the vailable styles and their preferred usage: 
+
+* List item (oe_theme_list_item): To be used on content lists with small thumbnails.
+* Featured list item (oe_theme_list_item_featured): To be used on highlights and content lists with big thumbnails.
+* Medium (oe_theme_medium_no_crop): Medium sized image, part of the Main content responsive image style.
+* Small (oe_theme_small_no_crop): Small sized image, part of the Main content responsive image style.
+* Main content (oe_theme_main_content): Responsive image style, to be used on any image that is rendered inside
+a content page.
+
 
 ## Development
 

--- a/templates/compositions/ec-component-content-item/content-item.html.twig
+++ b/templates/compositions/ec-component-content-item/content-item.html.twig
@@ -49,7 +49,7 @@
 
 {% macro image(src, alt, class1, class2) %}
   <div role="img" aria-label="{{ alt }}" class="ecl-u-ratio-3-2 ecl-u-flex-shrink-0 ecl-u-mr-xl {{ class1 }}"
-       style="background-image:url('{{ src }}');background-size:cover;height:5rem;width:7.5rem"></div>
+       style="background-image:url('{{ src }}');background-size:cover;height:8.75rem;width:13.125rem"></div>
   <div role="img" aria-label="{{ alt }}"
        class="ecl-u-ratio-3-2 ecl-u-flex-shrink-0 ecl-u-mr-xl ecl-u-d-none {{ class2 }}"
        style="background-image:url('{{ src }}');background-size:cover;height:8.75rem;width:13.125rem">

--- a/templates/compositions/ec-component-content-item/content-item.html.twig
+++ b/templates/compositions/ec-component-content-item/content-item.html.twig
@@ -49,10 +49,10 @@
 
 {% macro image(src, alt, class1, class2) %}
   <div role="img" aria-label="{{ alt }}" class="ecl-u-ratio-3-2 ecl-u-flex-shrink-0 ecl-u-mr-xl {{ class1 }}"
-       style="background-image:url('{{ src }}');background-size:contain;height:5rem;width:7.5rem"></div>
+       style="background-image:url('{{ src }}');background-size:cover;height:5rem;width:7.5rem"></div>
   <div role="img" aria-label="{{ alt }}"
        class="ecl-u-ratio-3-2 ecl-u-flex-shrink-0 ecl-u-mr-xl ecl-u-d-none {{ class2 }}"
-       style="background-image:url('{{ src }}');background-size:contain;height:8.75rem;width:13.125rem">
+       style="background-image:url('{{ src }}');background-size:cover;height:8.75rem;width:13.125rem">
   </div>
 {% endmacro %}
 

--- a/templates/ui_patterns_library/patterns-overview-page.html.twig
+++ b/templates/ui_patterns_library/patterns-overview-page.html.twig
@@ -24,7 +24,7 @@
   } %}
 
   {% for pattern_name, pattern in patterns %}
-  <div class="ecl-u-clearfix ecl-u-pv-l">
+  <div class="ecl-u-clearfix ecl-u-pv-4xl ecl-u-border-bottom ecl-u-border-color-grey-50">
     {# Pattern name and desciption. #}
     <a name="{{ pattern_name }}"></a>
     {% include '@ecl/link' with {
@@ -47,10 +47,9 @@
 
     {# Rendered pattern preview. #}
     {% set style = pattern.meta['#pattern'].additional.style %}
-    <div class="ecl-u-clearfix ecl-u-pv-xl" style="{{ style }}">
+    <div class="ecl-u-clearfix ecl-u-pt-4xl" style="{{ style }}">
       {{ pattern.rendered }}
     </div>
-    <hr>
   </div>
   {% endfor %}
 {% endif %}

--- a/templates/ui_patterns_library/patterns-variant-meta-information.html.twig
+++ b/templates/ui_patterns_library/patterns-variant-meta-information.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 {% if variant is not empty %}
-  <div class="ecl-u-pt-4xl ecl-u-pb-xl">
+  <div class="ecl-u-pt-2xl ecl-u-pb-xl">
     {% include '@ecl/table' with {
       zebra: true,
       headers: [

--- a/templates/ui_patterns_library/patterns-variant-meta-information.html.twig
+++ b/templates/ui_patterns_library/patterns-variant-meta-information.html.twig
@@ -5,21 +5,23 @@
  */
 #}
 {% if variant is not empty %}
-  {% include '@ecl/table' with {
-    zebra: true,
-    headers: [
-      [
-        { 'label': 'Variant'|t },
-        { 'label': 'Name'|t },
-        { 'label': 'Description'|t }
-      ]
-    ],
-    rows: [{
-      cells: [
-        { 'label': variant.label, 'data-ecl-table-header': 'Variant'|t },
-        { 'label': variant.name, 'data-ecl-table-header': 'Name'|t },
-        { 'label': variant.description, 'data-ecl-table-header': 'Description'|t }
-      ]
-    }]
-  } %}
+  <div class="ecl-u-pt-4xl ecl-u-pb-xl">
+    {% include '@ecl/table' with {
+      zebra: true,
+      headers: [
+        [
+          { 'label': 'Variant'|t },
+          { 'label': 'Name'|t },
+          { 'label': 'Description'|t }
+        ]
+      ],
+      rows: [{
+        cells: [
+          { 'label': variant.label, 'data-ecl-table-header': 'Variant'|t },
+          { 'label': variant.name, 'data-ecl-table-header': 'Name'|t },
+          { 'label': variant.description, 'data-ecl-table-header': 'Description'|t }
+        ]
+      }]
+    } %}
+  </div>
 {% endif %}


### PR DESCRIPTION
## OPENEUROPA-2192
### Description

Use ECL background image attribute and document image styles.

### Change log

- Added: Use ECL background image attribute and document image styles.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

