### PR TITLE
OPENEUROPA-2430: Create an "Icons with text" pattern.

### DIFF
--- a/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
+++ b/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
@@ -4,40 +4,31 @@
   /**
    * @file
    * Theme implementation for a ECL list of icons with text.
+   *
+   * Parameters:
+   *   - "items" (array) (default: [])
+   *     - "icon" (string) (default: 'file')
+   *     - "text" (string) (default: '')
    */
-Parameters:
-- "items" (array) (default: [])
-  - "icon" (string) (default: '')
-  - "text" (string) (default: '')
 #}
 
 {# Internal properties #}
 
 {% set _icon_path = icon_path|default('') %}
-{% set _extra_classes = 'ecl-u-mr-s' %}
-
-{# Internal logic - Process properties #}
-
-{% set _items = [] %}
-{% for item in  items %}
-  {% if item.icon and item.text %}
-    {% set _items = _items|merge([item]) %}
-  {% endif %}
-{% endfor %}
 
 {# Print the result #}
 
-{% if _items %}
+{% if items %}
 <ul class="ecl-unordered-list ecl-unordered-list--no-bullet">
-  {% for _item in _items %}
-    <li class="ecl-u-d-flex ecl-u-align-items-center ecl-unordered-list__item{% if not loop.first %} ecl-u-mt-l{% endif %}">
+  {% for _item in items if _item.text %}
+    <li class="ecl-u-d-flex ecl-u-align-items-center ecl-unordered-list__item{{ not loop.first ? ' ecl-u-mt-l' }}">
       {% include '@ecl/icon' with {
         icon: {
           path: _icon_path,
           type: 'general',
-          name: _item.icon
+          name: _item.icon|default('file')
         },
-        extra_classes: _extra_classes
+        extra_classes: 'ecl-u-mr-s'
       } only %}{{- _item.text -}}
     </li>
   {% endfor %}

--- a/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
+++ b/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
@@ -18,19 +18,20 @@ Parameters:
 {% set _extra_classes = 'ecl-u-mr-s' %}
 
 {# Print the result #}
-{% if _items not empty %}
+
+{% if _items %}
 <ul class="ecl-unordered-list ecl-unordered-list--no-bullet">
   {% for _item in _items %}
-  <li class="ecl-u-d-flex ecl-u-align-items-center ecl-unordered-list__item{% if not loop.first %} ecl-u-mt-l{% endif %}">
-    {% include '@ecl/icon' with {
-      icon: {
-        path: _icon_path,
-        type: 'general',
-        name: _item.icon
-      },
-      extra_classes: _extra_classes
-    } only %}{{- _item.text -}}
-  </li>
+    <li class="ecl-u-d-flex ecl-u-align-items-center ecl-unordered-list__item{% if not loop.first %} ecl-u-mt-l{% endif %}">
+      {% include '@ecl/icon' with {
+        icon: {
+          path: _icon_path,
+          type: 'general',
+          name: _item.icon
+        },
+        extra_classes: _extra_classes
+      } only %}{{- _item.text -}}
+    </li>
   {% endfor %}
 </ul>
 {% endif %}

--- a/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
+++ b/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
@@ -1,0 +1,37 @@
+{% spaceless %}
+
+{#
+  /**
+   * @file
+   * Theme implementation for a ECL list of icons with text.
+   */
+Parameters:
+- "items" (array) (default: [])
+  - "icon" (string) (default: '')
+  - "text" (string) (default: '')
+#}
+
+{# Internal properties #}
+
+{% set _items = items|default([]) %}
+{% set _icon_path = icon_path|default('') %}
+{% set _extra_classes = 'ecl-u-mr-s' %}
+
+{# Print the result #}
+{% if _items not empty %}
+<ul class="ecl-unordered-list ecl-unordered-list--no-bullet">
+  {% for _item in _items %}
+  <li class="ecl-u-d-flex ecl-u-align-items-center ecl-unordered-list__item{% if not loop.first %} ecl-u-mt-l{% endif %}">
+    {% include '@ecl/icon' with {
+      icon: {
+        path: _icon_path,
+        type: 'general',
+        name: _item.icon
+      },
+      extra_classes: _extra_classes
+    } only %}{{- _item.text -}}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}
+{% endspaceless %}

--- a/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
+++ b/templates/compositions/ec-component-icons-with-text/icons-with-text.html.twig
@@ -13,9 +13,17 @@ Parameters:
 
 {# Internal properties #}
 
-{% set _items = items|default([]) %}
 {% set _icon_path = icon_path|default('') %}
 {% set _extra_classes = 'ecl-u-mr-s' %}
+
+{# Internal logic - Process properties #}
+
+{% set _items = [] %}
+{% for item in  items %}
+  {% if item.icon and item.text %}
+    {% set _items = _items|merge([item]) %}
+  {% endif %}
+{% endfor %}
 
 {# Print the result #}
 

--- a/templates/patterns/icons_with_text/icons_with_text.ui_patterns.yml
+++ b/templates/patterns/icons_with_text/icons_with_text.ui_patterns.yml
@@ -1,0 +1,17 @@
+icons_with_text:
+  label: "Icons with text"
+  description: "A list of icons with a text."
+  fields:
+    items:
+      type: "array"
+      label: "Items"
+      description: "List of items, each having an 'icon' and a 'text' field"
+      preview:
+        - icon: "file"
+          text: "Culture | Innovation"
+        - icon: "calendar"
+          text: "15-16 November 2019, 08:00 AM"
+        - icon: "location"
+          text: "Brussels, Belgium"
+        - icon: "livestreaming"
+          text: "Live streaming available"

--- a/templates/patterns/icons_with_text/pattern-icons-with-text.html.twig
+++ b/templates/patterns/icons_with_text/pattern-icons-with-text.html.twig
@@ -1,0 +1,10 @@
+{#
+/**
+ * @file
+ * A list of icons with a text.
+ */
+#}
+{% include '@oe_theme/compositions/ec-component-icons-with-text/icons-with-text.html.twig' with {
+  'items': items|default([]),
+  'icon_path': ecl_icon_path,
+} only %}

--- a/templates/patterns/icons_with_text/pattern-icons-with-text.html.twig
+++ b/templates/patterns/icons_with_text/pattern-icons-with-text.html.twig
@@ -5,6 +5,6 @@
  */
 #}
 {% include '@oe_theme/compositions/ec-component-icons-with-text/icons-with-text.html.twig' with {
-  'items': items|default([]),
+  'items': items,
   'icon_path': ecl_icon_path,
 } only %}

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1470,3 +1470,37 @@
       'figcaption.ecl-media-container__caption': 0
     equals:
       'h2.ecl-u-type-heading-2': "Heading"
+- array:
+    '#type': pattern
+    '#id': icons_with_text
+    '#fields':
+      items:
+        -
+          icon: "file"
+          text: "Culture | Innovation"
+        -
+          icon: "calendar"
+          text: "15-16 November 2019, 08:00 AM"
+        -
+          icon: "location"
+          text: "Brussels, Belgium"
+        -
+          icon: "livestreaming"
+          text: "Live streaming available"
+  assertions:
+    count:
+      'ul.ecl-unordered-list--no-bullet': 1
+      'ul li.ecl-unordered-list__item': 4
+      'ul li.ecl-unordered-list__item svg': 4
+    equals:
+      'ul li.ecl-unordered-list__item:nth-child(1)': "Culture | Innovation"
+      'ul li.ecl-unordered-list__item:nth-child(2)': "15-16 November 2019, 08:00 AM"
+      'ul li.ecl-unordered-list__item:nth-child(3)': "Brussels, Belgium"
+      'ul li.ecl-unordered-list__item:nth-child(4)': "Live streaming available"
+- array:
+    '#type': pattern
+    '#id': icons_with_text
+    '#fields':
+  assertions:
+    count:
+      'ul.ecl-unordered-list--no-bullet': 0

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1521,8 +1521,9 @@
   assertions:
     count:
       'ul.ecl-unordered-list--no-bullet': 1
-      'ul li.ecl-unordered-list__item': 2
-      'ul li.ecl-unordered-list__item svg': 2
+      'ul li.ecl-unordered-list__item': 3
+      'ul li.ecl-unordered-list__item svg': 3
     equals:
       'ul li.ecl-unordered-list__item:nth-child(1)': "Culture | Innovation"
-      'ul li.ecl-unordered-list__item:nth-child(2)': "Live streaming available"
+      'ul li.ecl-unordered-list__item:nth-child(2)': "15-16 November 2019, 08:00 AM"
+      'ul li.ecl-unordered-list__item:nth-child(3)': "Live streaming available"

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1500,7 +1500,6 @@
 - array:
     '#type': pattern
     '#id': icons_with_text
-    '#fields':
   assertions:
     count:
       'ul.ecl-unordered-list--no-bullet': 0

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1503,3 +1503,26 @@
   assertions:
     count:
       'ul.ecl-unordered-list--no-bullet': 0
+- array:
+    '#type': pattern
+    '#id': icons_with_text
+    '#fields':
+      items:
+        -
+          icon: "file"
+          text: "Culture | Innovation"
+        -
+          text: "15-16 November 2019, 08:00 AM"
+        -
+          icon: "location"
+        -
+          icon: "livestreaming"
+          text: "Live streaming available"
+  assertions:
+    count:
+      'ul.ecl-unordered-list--no-bullet': 1
+      'ul li.ecl-unordered-list__item': 2
+      'ul li.ecl-unordered-list__item svg': 2
+    equals:
+      'ul li.ecl-unordered-list__item:nth-child(1)': "Culture | Innovation"
+      'ul li.ecl-unordered-list__item:nth-child(2)': "Live streaming available"


### PR DESCRIPTION
## OPENEUROPA-2430

### Description

We can offer this as a pattern and then use such a pattern as needed when theming content types.

We will implement this as a composition, i.e. we won't be asking ECL team to provide this as a component.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

