### PR TITLE
OPENEUROPA-2393: Make sure that javascript behaviours are bind once.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
     <env name="SIMPLETEST_BASE_URL" value="${drupal.base_url}"/>
     <env name="SIMPLETEST_DB" value="mysql://${drupal.database.user}:${drupal.database.password}@${drupal.database.host}:${drupal.database.port}/${drupal.database.name}"/>
     <env name="SIMPLETEST_SPARQL_DB" value="sparql://${drupal.sparql.host}:${drupal.sparql.port}/"/>
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["${selenium.browser}", null, "${selenium.host}:${selenium.port}/wd/hub"]'/>
   </php>
   <testsuites>
     <testsuite>

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -41,6 +41,7 @@ drupal:
 selenium:
   host: "http://selenium"
   port: "4444"
+  browser: "chrome"
 
 commands:
   drupal:site-setup:

--- a/tests/FunctionalJavascript/JavascriptBehavioursTest.php
+++ b/tests/FunctionalJavascript/JavascriptBehavioursTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\FunctionalJavascript;
+
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Tests the Javascript behaviours of the theme.
+ *
+ * @group oe_theme
+ */
+class JavascriptBehavioursTest extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'block',
+    'page_cache',
+    'dynamic_page_cache',
+    'oe_multilingual',
+    'oe_theme_helper',
+    'oe_theme_js_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Enable and set OpenEuropa Theme as default.
+    $this->container->get('theme_installer')->install(['oe_theme']);
+    $this->container->get('theme_handler')->setDefault('oe_theme');
+    $this->container->set('theme.registry', NULL);
+  }
+
+  /**
+   * Tests that ECL auto init is invoked and applied correctly.
+   */
+  public function testEclAutoInit(): void {
+    $this->drupalGet('/oe_theme_js_test/ajax_dropdown');
+
+    // Verify that the first dropdown button is shown, and it's collapsed.
+    $this->assertSession()->buttonExists('Dropdown 0');
+    $this->assertSession()->pageTextNotContains('Child link 0');
+
+    // Click the button to expand the dropdown and see the inner link.
+    $this->getSession()->getPage()->pressButton('Dropdown 0');
+    $this->assertSession()->pageTextContains('Child link 0');
+
+    // We need to close the dropdown now. Clicking on the container will do.
+    $this->getSession()->getPage()->find('css', '#dropdown-container')->click();
+
+    // Add a new dropdown.
+    $this->getSession()->getPage()->pressButton('Add another');
+    $this->assertSession()->assertWaitOnAjaxRequest();
+    // Both dropdowns are present and collapsed.
+    $this->assertSession()->buttonExists('Dropdown 0');
+    $this->assertSession()->pageTextNotContains('Child link 0');
+    $this->assertSession()->buttonExists('Dropdown 1');
+    $this->assertSession()->pageTextNotContains('Child link 1');
+
+    // Verify that the first dropdown opens correctly.
+    $this->getSession()->getPage()->pressButton('Dropdown 0');
+    $this->assertSession()->pageTextContains('Child link 0');
+    $this->assertSession()->pageTextNotContains('Child link 1');
+    // Verify that the JS behaviours initialised ECL on the second dropdown.
+    $this->getSession()->getPage()->pressButton('Dropdown 1');
+    $this->assertSession()->pageTextContains('Child link 1');
+    $this->assertSession()->pageTextNotContains('Child link 0');
+  }
+
+}

--- a/tests/modules/oe_theme_js_test/oe_theme_js_test.info.yml
+++ b/tests/modules/oe_theme_js_test/oe_theme_js_test.info.yml
@@ -1,0 +1,5 @@
+name: 'OpenEuropa Theme Javascript Test'
+description: 'Support module for Javascript related tests.'
+type: module
+core: 8.x
+package: Testing

--- a/tests/modules/oe_theme_js_test/oe_theme_js_test.routing.yml
+++ b/tests/modules/oe_theme_js_test/oe_theme_js_test.routing.yml
@@ -1,0 +1,7 @@
+oe_theme_js_test.ajax_rebuild_test_form:
+  path: '/oe_theme_js_test/ajax_dropdown'
+  defaults:
+    _form: 'Drupal\oe_theme_js_test\Form\AjaxDropdownsTestForm'
+    _title: 'Ajax dropdowns test form'
+  requirements:
+    _access: 'TRUE'

--- a/tests/modules/oe_theme_js_test/src/Form/AjaxDropdownsTestForm.php
+++ b/tests/modules/oe_theme_js_test/src/Form/AjaxDropdownsTestForm.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_js_test\Form;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\AppendCommand;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\Url;
+
+/**
+ * A form that simulates adding dropdowns through AJAX.
+ */
+class AjaxDropdownsTestForm implements FormInterface {
+
+  use StringTranslationTrait;
+  use DependencySerializationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'oe_theme_js_test_ajax_rebuild_test_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $max_delta = $form_state->get('max_delta') ?? 0;
+
+    $form['dropdowns'] = [
+      '#type' => 'container',
+      '#attributes' => [
+        'id' => 'dropdown-container',
+        // We need to space the patterns from the submit button.
+        'class' => ['ecl-u-clearfix', 'ecl-u-pv-4xl'],
+      ],
+    ];
+
+    for ($i = 0; $i <= $max_delta; $i++) {
+      $form['dropdowns'][$i] = [
+        '#type' => 'pattern',
+        '#id' => 'dropdown',
+        '#fields' => [
+          'button_label' => $this->t('Dropdown @count', ['@count' => $i]),
+          'links' => [
+            [
+              'url' => Url::fromRoute('<front>'),
+              'label' => $this->t('Child link @count', ['@count' => $i]),
+            ],
+          ],
+        ],
+      ];
+    }
+
+    $form['add_more'] = [
+      '#type' => 'submit',
+      '#name' => 'add_more',
+      '#value' => t('Add another'),
+      '#submit' => [[get_class($this), 'addMoreSubmit']],
+      '#ajax' => [
+        'callback' => [get_class($this), 'addMoreAjax'],
+        'wrapper' => 'dropdown-container',
+        'effect' => 'fade',
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    // Do nothing.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Do nothing.
+  }
+
+  /**
+   * Submit handler for the add more submit button.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current form state.
+   */
+  public static function addMoreSubmit(array $form, FormStateInterface $form_state) {
+    $max_delta = $form_state->get('max_delta');
+    $form_state->set('max_delta', ++$max_delta);
+    $form_state->setRebuild();
+  }
+
+  /**
+   * Ajax callback that returns the latest added element.
+   */
+  public static function addMoreAjax(array $form, FormStateInterface $form_state) {
+    $max_delta = $form_state->get('max_delta');
+
+    $response = new AjaxResponse();
+    $html = \Drupal::service('renderer')->renderRoot($form['dropdowns'][$max_delta]);
+    $response->addCommand(new AppendCommand('#dropdown-container', $html));
+    $response->setAttachments($form['dropdowns'][$max_delta]['#attached']);
+
+    return $response;
+  }
+
+}


### PR DESCRIPTION
If ajax is used then the DOM changes and Drupal.behaviours binds event on the element more than once. Resulting in faulty behaviors such as toggles won't work anymore. http://d7.thecarneyeffect.co.uk/applying-javascript-behaviours-once-drupal

"Any object defined as a property of Drupal.behaviors will get its attach() method called when the DOM has loaded both initially and after any AJAX calls."

Check all JS files in oe_theme, and evaluate case by case the usage of .once() context to make sure it binds only once.

https://www.drupal.org/docs/8/api/javascript-api/javascript-api-overview