### PR TITLE
OPENEUROPA-2612: Remove underline from cards title.

### DIFF
--- a/templates/patterns/featured_item/pattern-featured-item.html.twig
+++ b/templates/patterns/featured_item/pattern-featured-item.html.twig
@@ -38,8 +38,10 @@
   'description': _description|default(description),
   'meta': metas,
   'title': {
+    'variant': "standalone",
     'label': title,
-    'path': link.href
+    'path': link.href,
+    'type': "standalone"
   },
   'image': image
 } %}

--- a/templates/patterns/featured_item/pattern-featured-item.html.twig
+++ b/templates/patterns/featured_item/pattern-featured-item.html.twig
@@ -38,7 +38,6 @@
   'description': _description|default(description),
   'meta': metas,
   'title': {
-    'variant': "standalone",
     'label': title,
     'path': link.href,
     'type': "standalone"

--- a/templates/patterns/list_item/pattern-list-item--variant-block.html.twig
+++ b/templates/patterns/list_item/pattern-list-item--variant-block.html.twig
@@ -8,7 +8,8 @@
   card : {
     title: {
       label: title,
-      path: url
+      path: url,
+      type: "standalone"
     },
     description: detail
   }

--- a/templates/patterns/list_item/pattern-list-item--variant-highlight.html.twig
+++ b/templates/patterns/list_item/pattern-list-item--variant-highlight.html.twig
@@ -8,7 +8,8 @@
   card: {
     title: {
       label: title,
-      path: url
+      path: url,
+      type: "standalone"
     },
     image: image
   }

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -444,7 +444,7 @@
         alt: "Alternate text for secondary image"
   assertions:
     count:
-      article.ecl-card header.ecl-card__header h1.ecl-card__title a.ecl-link[href="http://example.com"]: 1
+      article.ecl-card header.ecl-card__header h1.ecl-card__title a.ecl-link--standalone[href="http://example.com"]: 1
       article.ecl-card header.ecl-card__header div.ecl-card__image[aria-label="Alternate text for secondary image"]: 1
       article.ecl-card header.ecl-card__header div.ecl-card__image[style="background-image:url('http://via.placeholder.com/300x300')"]: 1
       article.ecl-card header.ecl-card__header div.ecl-card__meta: 0
@@ -462,7 +462,7 @@
       detail: "Item test"
   assertions:
     count:
-      'article.ecl-card header.ecl-card__header h1.ecl-card__title a.ecl-link[href="http://example.com"]': 1
+      'article.ecl-card header.ecl-card__header h1.ecl-card__title a.ecl-link--standalone[href="http://example.com"]': 1
       'article.ecl-card header.ecl-card__header div.ecl-card__image': 0
       'article.ecl-card header.ecl-card__header div.ecl-card__meta': 0
     equals:

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1222,7 +1222,7 @@
   assertions:
     count:
       "div.ecl-card__image[style=\"background-image:url('http://via.placeholder.com/120x80')\"]": 1
-      'h1.ecl-card__title a[href="https://example.com"]': 1
+      'h1.ecl-card__title a.ecl-link--standalone[href="https://example.com"]': 1
       'a.ecl-button': 0
     equals:
       'div.ecl-card__meta': "Breaking news article | Brussels"
@@ -1241,7 +1241,7 @@
   assertions:
     count:
       "div.ecl-card__image": 0
-      'h1.ecl-card__title a[href="https://example.com"]': 1
+      'h1.ecl-card__title a.ecl-link--standalone[href="https://example.com"]': 1
       'a.ecl-button[href="https://example.com"]': 1
     equals:
       'h1.ecl-card__title a': "Example title"


### PR DESCRIPTION
## OPENEUROPA-2612

### Description

Remove underline from cards title.

### Change log

- Added:
- Changed: Set title variant and type to standalone for featured item pattern.
- Deprecated:
- Removed:
- Fixed:
- Security:

