### PR TITLE
OPENEUROPA-2614: Make sure elements are not shown when related fields are empty.

### DIFF
--- a/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
+++ b/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
@@ -6,9 +6,29 @@
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
+
+{#
+  Unfortunately even when the field is empty the variable content.* still contains information (such as the weight)
+  so we can't pass it to the pattern directly.
+ #}
+{% set _title = '' %}
+{% if not (paragraph.field_oe_title.isEmpty == true) and content.field_oe_title is defined %}
+  {% set _title = content.field_oe_title %}
+{% endif %}
+
+{% set _caption = '' %}
+{% if not (paragraph.field_oe_plain_text_long.isEmpty == true) and content.field_oe_plain_text_long is defined %}
+  {% set _caption = content.field_oe_plain_text_long %}
+{% endif %}
+
+{% set _text = '' %}
+{% if not (paragraph.field_oe_text_long.isEmpty == true) and content.field_oe_text_long is defined %}
+  {% set _text = content.field_oe_text_long %}
+{% endif %}
+
 {{ pattern('text_featured_media', {
-    'title': content.field_oe_title,
+    'title': _title,
     'image': image,
-    'caption': content.field_oe_plain_text_long,
-    'text': content.field_oe_text_long,
+    'caption': _caption,
+    'text': _text,
 }) }}

--- a/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
+++ b/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
@@ -11,21 +11,10 @@
   Unfortunately even when the field is empty the variable content.* still contains information (such as the weight)
   so we can't pass it to the pattern directly.
  #}
-{% if not (paragraph.field_oe_title.isEmpty == true) and content.field_oe_title is defined %}
-  {% set _title = content.field_oe_title %}
-{% endif %}
-
-{% if not (paragraph.field_oe_plain_text_long.isEmpty == true) and content.field_oe_plain_text_long is defined %}
-  {% set _caption = content.field_oe_plain_text_long %}
-{% endif %}
-
-{% if not (paragraph.field_oe_text_long.isEmpty == true) and content.field_oe_text_long is defined %}
-  {% set _text = content.field_oe_text_long %}
-{% endif %}
 
 {{ pattern('text_featured_media', {
-    'title': _title|default(''),
-    'image': image,
-    'caption': _caption|default(''),
-    'text': _text|default(''),
+  'title': not paragraph.field_oe_title.isEmpty ? content.field_oe_title,
+  'image': not paragraph.field_oe_image.isEmpty ? image,
+  'caption': not paragraph.field_oe_plain_text_long.isEmpty ? content.field_oe_plain_text_long,
+  'text': not paragraph.field_oe_text_long.isEmpty ? content.field_oe_text_long,
 }) }}

--- a/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
+++ b/templates/paragraphs/paragraph--oe-text-feature-media.html.twig
@@ -11,24 +11,21 @@
   Unfortunately even when the field is empty the variable content.* still contains information (such as the weight)
   so we can't pass it to the pattern directly.
  #}
-{% set _title = '' %}
 {% if not (paragraph.field_oe_title.isEmpty == true) and content.field_oe_title is defined %}
   {% set _title = content.field_oe_title %}
 {% endif %}
 
-{% set _caption = '' %}
 {% if not (paragraph.field_oe_plain_text_long.isEmpty == true) and content.field_oe_plain_text_long is defined %}
   {% set _caption = content.field_oe_plain_text_long %}
 {% endif %}
 
-{% set _text = '' %}
 {% if not (paragraph.field_oe_text_long.isEmpty == true) and content.field_oe_text_long is defined %}
   {% set _text = content.field_oe_text_long %}
 {% endif %}
 
 {{ pattern('text_featured_media', {
-    'title': _title,
+    'title': _title|default(''),
     'image': image,
-    'caption': _caption,
-    'text': _text,
+    'caption': _caption|default(''),
+    'text': _text|default(''),
 }) }}

--- a/tests/Kernel/Paragraphs/MediaParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/MediaParagraphsTest.php
@@ -125,6 +125,32 @@ class MediaParagraphsTest extends ParagraphsTestBase {
     $text = $crawler->filter('.ecl-col-md-6.ecl-editor');
     $this->assertCount(1, $text);
     $this->assertContains('Full text', $text->text());
+
+    // Remove the caption and assert the element is no longer rendered.
+    $paragraph->set('field_oe_plain_text_long', '');
+    $paragraph->save();
+
+    $html = $this->renderParagraph($paragraph);
+    $crawler = new Crawler($html);
+    $figure = $crawler->filter('figure.ecl-media-container');
+    $this->assertCount(1, $figure);
+    // The image in the figure element has the source and alt defined in the
+    // referenced media but the caption is no longer rendered.
+    $image = $figure->filter('.ecl-media-container__media');
+    $this->assertContains('/example_1.jpeg', $image->attr('src'));
+    $this->assertContains('Alt', $image->attr('alt'));
+    $caption = $figure->filter('.ecl-media-container__caption');
+    $this->assertCount(0, $caption);
+
+    // Remove the text and assert the element is no longer rendered.
+    $paragraph->set('field_oe_text_long', '');
+    $paragraph->save();
+
+    $html = $this->renderParagraph($paragraph);
+    $crawler = new Crawler($html);
+    // Assert text is no longer rendered.
+    $text = $crawler->filter('.ecl-editor');
+    $this->assertCount(0, $text);
   }
 
 }

--- a/tests/Kernel/Paragraphs/MediaParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/MediaParagraphsTest.php
@@ -151,6 +151,16 @@ class MediaParagraphsTest extends ParagraphsTestBase {
     // Assert text is no longer rendered.
     $text = $crawler->filter('.ecl-editor');
     $this->assertCount(0, $text);
+
+    // Remove the title and assert the element is no longer rendered.
+    $paragraph->set('field_oe_title', '');
+    $paragraph->save();
+
+    $html = $this->renderParagraph($paragraph);
+    $crawler = new Crawler($html);
+    // Assert title is no longer rendered.
+    $title = $crawler->filter('h2.ecl-u-type-heading-2');
+    $this->assertCount(0, $title);
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-2614

### Description

Caption should not be shown when empty in the rich text and media paragraph	

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: Make sure elements are not shown when related fields are empty on text with featured media paragraph.
- Security:

### Commands

```sh
[Insert commands here]

```

