### PR TITLE
ISSUE-386: Add support for extra container classes in select template.

### DIFF
--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -11,13 +11,19 @@
   {% set extra_classes = extra_classes|merge(['ecl-select--invalid']) %}
 {% endif %}
 
-{% set wrapper_attributes = create_attribute({'class': 'ecl-select__container'}) %}
+{# Set default wrapper classes. #}
+{# This also allows overriding templates to take control of classes like width modifiers. #}
+{% set wrapper_classes = wrapper_classes|default([
+  'ecl-select__container',
+  'ecl-select__container--m',
+]) %}
+
+{% set wrapper_attributes = create_attribute({'class': wrapper_classes}) %}
+
 {% if disabled %}
   {% set wrapper_attributes = wrapper_attributes.addClass('ecl-select__container--disabled') %}
 {% endif %}
-{% if wrapper_classes is defined and wrapper_classes is not empty %}
-  {% set wrapper_attributes = wrapper_attributes.addClass(wrapper_classes) %}
-{% endif %}
+
 {% spaceless %}
   <div{{ wrapper_attributes }}>
     <select{{ attributes.addClass(extra_classes) }}>

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -6,13 +6,21 @@
  * @see ./core/themes/stable/templates/form/select.html.twig
  */
 #}
-{% set extra_attributes = ['ecl-select'] %}
+{% set extra_classes = ['ecl-select'] %}
 {% if attributes.hasClass('error') %}
-  {% set extra_attributes = extra_attributes|merge(['ecl-select--invalid']) %}
+  {% set extra_classes = extra_classes|merge(['ecl-select--invalid']) %}
+{% endif %}
+
+{% set wrapper_attributes = create_attribute({'class': 'ecl-select__container'}) %}
+{% if disabled %}
+  {% set wrapper_attributes = wrapper_attributes.addClass('ecl-select__container--disabled') %}
+{% endif %}
+{% if wrapper_classes is defined and wrapper_classes is not empty %}
+  {% set wrapper_attributes = wrapper_attributes.addClass(wrapper_classes) %}
 {% endif %}
 {% spaceless %}
-  <div class="ecl-select__container{{ disabled ? ' ecl-select__container--disabled' }}">
-    <select{{ attributes.addClass(extra_attributes) }}>
+  <div{{ wrapper_attributes }}>
+    <select{{ attributes.addClass(extra_classes) }}>
       {% for option in options %}
         {% if option.type == 'optgroup' %}
           <optgroup label="{{ option.label }}">

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -55,7 +55,11 @@
   assert:
     contains:
       - 'Select element'
+      - '<option value="1">One</option>'
+      - '<option value="2">Two</option>'
+      - '<option value="3">Three</option>'
     count:
+      'div.ecl-select__container.ecl-select__container--m': 1
       'select.form-select.ecl-select': 1
 - array:
     '#type': radios


### PR DESCRIPTION
## ISSUE-386

### Description

Add support for additional container classes for select element so that container width modifier classes (see here under 'Widths': https://ec.europa.eu/component-library/ec/components/forms/select/code/ )  can be passed to the template.

### Change log

- Changed: 
./templates/form/select.html.twig
- Added 'wrapper_attributes' that accepts 'wrapper_classes' variable.
- Renamed 'extra_attributes' to 'extra_classes'

