### PR TITLE
OPENEUROPA-2642: Create a formatter for address field.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
         "drupal/core": "^8.7",
         "drupal/ui_patterns": "^1.0",
         "openeuropa/ecl-twig-loader": "~2.0",
-        "php": "^7.1",
-        "twig/twig": "~1.41"
+        "php": "^7.1"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.0",
@@ -18,6 +17,7 @@
         "consolidation/robo": "~1.4",
         "consolidation/annotated-command": "^2.8.2",
         "drupal-composer/drupal-scaffold": "^2.5.2",
+        "drupal/address": "^1.7",
         "drupal/config_devel": "~1.2",
         "drupal/drupal-driver": "~2.0.0-alpha6",
         "drupal/drupal-extension": "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "drupal/core": "^8.7",
         "drupal/ui_patterns": "^1.0",
         "openeuropa/ecl-twig-loader": "~2.0",
-        "php": "^7.1"
+        "php": "^7.1",
+        "twig/twig": "~1.41"
     },
     "require-dev": {
         "cweagans/composer-patches": "~1.0",

--- a/modules/oe_theme_helper/config/schema/oe_theme_helper.schema.yml
+++ b/modules/oe_theme_helper/config/schema/oe_theme_helper.schema.yml
@@ -5,3 +5,11 @@ image.effect.retina_image_scale:
     multiplier:
       type: integer
       label: 'Multiplier'
+
+field.formatter.settings.oe_theme_helper_address_inline:
+  type: mapping
+  label: 'Address inline formatter settings'
+  mapping:
+    delimiter:
+      type: string
+      label: 'Delimiter for address items.'

--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -46,3 +46,18 @@ function oe_theme_helper_entity_view_alter(array &$build, EntityInterface $entit
   // show at the top, above any other elements.
   $build['content_moderation_control']['#weight'] = -500;
 }
+
+/**
+ * Implements hook_theme().
+ */
+function oe_theme_helper_theme($existing, $type, $theme, $path) {
+  return [
+    'oe_theme_helper_address_inline' => [
+      'variables' => [
+        'address' => NULL,
+        'address_items' => [],
+        'address_delimiter' => NULL,
+      ],
+    ],
+  ];
+}

--- a/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
+++ b/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
@@ -4,21 +4,13 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme_helper\Plugin\Field\FieldFormatter;
 
-use CommerceGuys\Addressing\AddressFormat\AddressField;
-use CommerceGuys\Addressing\AddressFormat\AddressFormat;
-use CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface;
-use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Locale;
-use CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface;
 use Drupal\address\AddressInterface;
+use Drupal\address\Plugin\Field\FieldFormatter\AddressDefaultFormatter;
 use Drupal\Component\Utility\Html;
-use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Format an address inline with locale format and a configurable separator.
@@ -31,81 +23,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   },
  * )
  */
-class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
-
-  /**
-   * The address format repository.
-   *
-   * @var \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface
-   */
-  protected $addressFormatRepository;
-
-  /**
-   * The country repository.
-   *
-   * @var \CommerceGuys\Addressing\Country\CountryRepositoryInterface
-   */
-  protected $countryRepository;
-
-  /**
-   * The subdivision repository.
-   *
-   * @var \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface
-   */
-  protected $subdivisionRepository;
-
-  /**
-   * Constructs an AddressDefaultFormatter object.
-   *
-   * @param string $plugin_id
-   *   The plugin_id for the formatter.
-   * @param mixed $plugin_definition
-   *   The plugin implementation definition.
-   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
-   *   The definition of the field to which the formatter is associated.
-   * @param array $settings
-   *   The formatter settings.
-   * @param string $label
-   *   The formatter label display setting.
-   * @param string $view_mode
-   *   The view mode.
-   * @param array $third_party_settings
-   *   Any third party settings.
-   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface $address_format_repository
-   *   The address format repository.
-   * @param \CommerceGuys\Addressing\Country\CountryRepositoryInterface $country_repository
-   *   The country repository.
-   * @param \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface $subdivision_repository
-   *   The subdivision repository.
-   *
-   * @SuppressWarnings(PHPMD.ExcessiveParameterList)
-   */
-  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, AddressFormatRepositoryInterface $address_format_repository, CountryRepositoryInterface $country_repository, SubdivisionRepositoryInterface $subdivision_repository) {
-    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
-
-    $this->addressFormatRepository = $address_format_repository;
-    $this->countryRepository = $country_repository;
-    $this->subdivisionRepository = $subdivision_repository;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    // @see \Drupal\Core\Field\FormatterPluginManager::createInstance().
-    return new static(
-      $plugin_id,
-      $plugin_definition,
-      $configuration['field_definition'],
-      $configuration['settings'],
-      $configuration['label'],
-      $configuration['view_mode'],
-      $configuration['third_party_settings'],
-      $container->get('address.address_format_repository'),
-      $container->get('address.country_repository'),
-      $container->get('address.subdivision_repository')
-    );
-  }
+class AddressInlineFormatter extends AddressDefaultFormatter {
 
   /**
    * {@inheritdoc}
@@ -184,7 +102,7 @@ class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPl
       $format_string = $address_format->getFormat() . "\n" . '%country';
     }
 
-    $items = self::replacePlaceholders($format_string, $address_elements);
+    $items = $this->extractAddressItems($format_string, $address_elements);
 
     return [
       '#theme' => 'oe_theme_helper_address_inline',
@@ -200,17 +118,17 @@ class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPl
   }
 
   /**
-   * Replaces placeholders in the given string.
+   * Extract address items from a format string and replaces placeholders.
    *
    * @param string $string
-   *   The string containing the placeholders.
+   *   The address format string, containing placeholders.
    * @param array $replacements
-   *   An array of replacements keyed by their placeholders.
+   *   An array of address items.
    *
    * @return array
    *   The exploded lines.
    */
-  public static function replacePlaceholders(string $string, array $replacements): array {
+  protected function extractAddressItems(string $string, array $replacements): array {
     // Make sure the replacements don't have any unneeded newlines.
     $replacements = array_map('trim', $replacements);
     $string = strtr($string, $replacements);
@@ -226,52 +144,6 @@ class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPl
     $lines = array_filter($lines);
 
     return $lines;
-  }
-
-  /**
-   * Gets the address values used for rendering.
-   *
-   * @param \Drupal\address\AddressInterface $address
-   *   The address.
-   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormat $address_format
-   *   The address format.
-   *
-   * @return array
-   *   The values, keyed by address field.
-   */
-  protected function getValues(AddressInterface $address, AddressFormat $address_format): array {
-    $values = [];
-    foreach (AddressField::getAll() as $field) {
-      $getter = 'get' . ucfirst($field);
-      $values[$field] = $address->$getter();
-    }
-
-    $original_values = [];
-    $subdivision_fields = $address_format->getUsedSubdivisionFields();
-    $parents = [];
-    foreach ($subdivision_fields as $index => $field) {
-      if (empty($values[$field])) {
-        // This level is empty, so there can be no sublevels.
-        break;
-      }
-      $parents[] = $index ? $original_values[$subdivision_fields[$index - 1]] : $address->getCountryCode();
-      $subdivision = $this->subdivisionRepository->get($values[$field], $parents);
-      if (!$subdivision) {
-        break;
-      }
-
-      // Remember the original value so that it can be used for $parents.
-      $original_values[$field] = $values[$field];
-      // Replace the value with the expected code.
-      $use_local_name = Locale::matchCandidates($address->getLocale(), $subdivision->getLocale());
-      $values[$field] = $use_local_name ? $subdivision->getLocalCode() : $subdivision->getCode();
-      if (!$subdivision->hasChildren()) {
-        // The current subdivision has no children, stop.
-        break;
-      }
-    }
-
-    return $values;
   }
 
 }

--- a/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
+++ b/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
@@ -4,17 +4,24 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme_helper\Plugin\Field\FieldFormatter;
 
+use CommerceGuys\Addressing\AddressFormat\AddressField;
+use CommerceGuys\Addressing\AddressFormat\AddressFormat;
+use CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface;
+use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Locale;
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface;
 use Drupal\address\AddressInterface;
-use Drupal\address\Plugin\Field\FieldFormatter\AddressDefaultFormatter;
 use Drupal\Component\Utility\Html;
+use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Plugin implementation of the 'oe_theme_helper_address_inline' formatter.
+ * Format an address inline with locale format and a configurable separator.
  *
  * @FieldFormatter(
  *   id = "oe_theme_helper_address_inline",
@@ -24,7 +31,81 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
  *   },
  * )
  */
-class AddressInlineFormatter extends AddressDefaultFormatter implements ContainerFactoryPluginInterface {
+class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The address format repository.
+   *
+   * @var \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface
+   */
+  protected $addressFormatRepository;
+
+  /**
+   * The country repository.
+   *
+   * @var \CommerceGuys\Addressing\Country\CountryRepositoryInterface
+   */
+  protected $countryRepository;
+
+  /**
+   * The subdivision repository.
+   *
+   * @var \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface
+   */
+  protected $subdivisionRepository;
+
+  /**
+   * Constructs an AddressDefaultFormatter object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface $address_format_repository
+   *   The address format repository.
+   * @param \CommerceGuys\Addressing\Country\CountryRepositoryInterface $country_repository
+   *   The country repository.
+   * @param \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface $subdivision_repository
+   *   The subdivision repository.
+   *
+   * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, AddressFormatRepositoryInterface $address_format_repository, CountryRepositoryInterface $country_repository, SubdivisionRepositoryInterface $subdivision_repository) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->addressFormatRepository = $address_format_repository;
+    $this->countryRepository = $country_repository;
+    $this->subdivisionRepository = $subdivision_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    // @see \Drupal\Core\Field\FormatterPluginManager::createInstance().
+    return new static(
+      $plugin_id,
+      $plugin_definition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('address.address_format_repository'),
+      $container->get('address.country_repository'),
+      $container->get('address.subdivision_repository')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -32,20 +113,20 @@ class AddressInlineFormatter extends AddressDefaultFormatter implements Containe
   public static function defaultSettings() {
     return [
       'delimiter' => ', ',
-    ] + parent::defaultSettings();
+    ];
   }
 
   /**
    * {@inheritdoc}
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
-    $form = parent::settingsForm($form, $form_state);
 
     $form['delimiter'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Delimiter'),
       '#default_value' => $this->getSetting('delimiter'),
       '#description' => $this->t('Specify delimiter between address items.'),
+      '#required' => TRUE,
     ];
 
     return $form;
@@ -55,15 +136,11 @@ class AddressInlineFormatter extends AddressDefaultFormatter implements Containe
    * {@inheritdoc}
    */
   public function settingsSummary() {
-    $settings_summary = parent::settingsSummary();
-    $example_address_items = [
-      'Rue de la Loi',
-      '56',
-      '1000',
-      'Brussels',
+    return [
+      $this->t('Delimiter: @delimiter', [
+        '@delimiter' => $this->getSetting('delimiter'),
+      ]),
     ];
-    $settings_summary[] = implode($this->getSetting('delimiter'), $example_address_items);
-    return $settings_summary;
   }
 
   /**
@@ -133,7 +210,7 @@ class AddressInlineFormatter extends AddressDefaultFormatter implements Containe
    * @return array
    *   The exploded lines.
    */
-  public static function replacePlaceholders($string, array $replacements) {
+  public static function replacePlaceholders(string $string, array $replacements): array {
     // Make sure the replacements don't have any unneeded newlines.
     $replacements = array_map('trim', $replacements);
     $string = strtr($string, $replacements);
@@ -149,6 +226,52 @@ class AddressInlineFormatter extends AddressDefaultFormatter implements Containe
     $lines = array_filter($lines);
 
     return $lines;
+  }
+
+  /**
+   * Gets the address values used for rendering.
+   *
+   * @param \Drupal\address\AddressInterface $address
+   *   The address.
+   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormat $address_format
+   *   The address format.
+   *
+   * @return array
+   *   The values, keyed by address field.
+   */
+  protected function getValues(AddressInterface $address, AddressFormat $address_format): array {
+    $values = [];
+    foreach (AddressField::getAll() as $field) {
+      $getter = 'get' . ucfirst($field);
+      $values[$field] = $address->$getter();
+    }
+
+    $original_values = [];
+    $subdivision_fields = $address_format->getUsedSubdivisionFields();
+    $parents = [];
+    foreach ($subdivision_fields as $index => $field) {
+      if (empty($values[$field])) {
+        // This level is empty, so there can be no sublevels.
+        break;
+      }
+      $parents[] = $index ? $original_values[$subdivision_fields[$index - 1]] : $address->getCountryCode();
+      $subdivision = $this->subdivisionRepository->get($values[$field], $parents);
+      if (!$subdivision) {
+        break;
+      }
+
+      // Remember the original value so that it can be used for $parents.
+      $original_values[$field] = $values[$field];
+      // Replace the value with the expected code.
+      $use_local_name = Locale::matchCandidates($address->getLocale(), $subdivision->getLocale());
+      $values[$field] = $use_local_name ? $subdivision->getLocalCode() : $subdivision->getCode();
+      if (!$subdivision->hasChildren()) {
+        // The current subdivision has no children, stop.
+        break;
+      }
+    }
+
+    return $values;
   }
 
 }

--- a/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
+++ b/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_helper\Plugin\Field\FieldFormatter;
+
+use CommerceGuys\Addressing\AddressFormat\AddressField;
+use CommerceGuys\Addressing\AddressFormat\AddressFormat;
+use CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface;
+use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
+use CommerceGuys\Addressing\Locale;
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface;
+use Drupal\address\AddressInterface;
+use Drupal\Core\Field\FieldDefinitionInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\FormatterBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the 'oe_address_inline' formatter.
+ *
+ * @FieldFormatter(
+ *   id = "oe_address_inline",
+ *   label = @Translation("Inline address"),
+ *   field_types = {
+ *     "address",
+ *   },
+ * )
+ */
+class AddressInlineFormatter extends FormatterBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The address format repository.
+   *
+   * @var \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface
+   */
+  protected $addressFormatRepository;
+
+  /**
+   * The country repository.
+   *
+   * @var \CommerceGuys\Addressing\Country\CountryRepositoryInterface
+   */
+  protected $countryRepository;
+
+  /**
+   * The subdivision repository.
+   *
+   * @var \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface
+   */
+  protected $subdivisionRepository;
+
+  /**
+   * Constructs an AddressPlainFormatter object.
+   *
+   * @param string $plugin_id
+   *   The plugin_id for the formatter.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Field\FieldDefinitionInterface $field_definition
+   *   The definition of the field to which the formatter is associated.
+   * @param array $settings
+   *   The formatter settings.
+   * @param string $label
+   *   The formatter label display setting.
+   * @param string $view_mode
+   *   The view mode.
+   * @param array $third_party_settings
+   *   Any third party settings.
+   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface $address_format_repository
+   *   The address format repository.
+   * @param \CommerceGuys\Addressing\Country\CountryRepositoryInterface $country_repository
+   *   The country repository.
+   * @param \CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface $subdivision_repository
+   *   The subdivision repository.
+   *
+   * @SuppressWarnings(PHPMD.ExcessiveParameterList)
+   */
+  public function __construct($plugin_id, $plugin_definition, FieldDefinitionInterface $field_definition, array $settings, $label, $view_mode, array $third_party_settings, AddressFormatRepositoryInterface $address_format_repository, CountryRepositoryInterface $country_repository, SubdivisionRepositoryInterface $subdivision_repository) {
+    parent::__construct($plugin_id, $plugin_definition, $field_definition, $settings, $label, $view_mode, $third_party_settings);
+
+    $this->addressFormatRepository = $address_format_repository;
+    $this->countryRepository = $country_repository;
+    $this->subdivisionRepository = $subdivision_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $pluginId, $pluginDefinition) {
+    // @see \Drupal\Core\Field\FormatterPluginManager::createInstance().
+    return new static(
+      $pluginId,
+      $pluginDefinition,
+      $configuration['field_definition'],
+      $configuration['settings'],
+      $configuration['label'],
+      $configuration['view_mode'],
+      $configuration['third_party_settings'],
+      $container->get('address.address_format_repository'),
+      $container->get('address.country_repository'),
+      $container->get('address.subdivision_repository')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function defaultSettings() {
+    return [
+      'delimiter' => ', ',
+    ] + parent::defaultSettings();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $form, FormStateInterface $form_state) {
+    $form = parent::settingsForm($form, $form_state);
+
+    $form['delimiter'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Delimiter'),
+      '#default_value' => $this->getSetting('delimiter'),
+      '#description' => $this->t('Specify delimiter between address items.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsSummary() {
+    $settings_summary = parent::settingsSummary();
+    $example_address_items = [
+      'Rue de la Loi',
+      '56',
+      '1000',
+      'Brussels',
+    ];
+    $settings_summary[] = implode($this->getSetting('delimiter'), $example_address_items);
+    return $settings_summary;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(FieldItemListInterface $items, $langcode) {
+    $elements = [];
+    foreach ($items as $delta => $item) {
+      $elements[$delta] = $this->viewElement($item, $langcode);
+    }
+
+    return $elements;
+  }
+
+  /**
+   * Builds a renderable array for a single address item.
+   *
+   * @param \Drupal\address\AddressInterface $address
+   *   The address.
+   * @param string $langcode
+   *   The language that should be used to render the field.
+   *
+   * @return array
+   *   A renderable array.
+   */
+  protected function viewElement(AddressInterface $address, $langcode) {
+    $country_code = $address->getCountryCode();
+    $countries = $this->countryRepository->getList();
+    $address_format = $this->addressFormatRepository->get($country_code);
+    $values = $this->getValues($address, $address_format);
+    $values['country'] = $countries[$country_code];
+    return [
+      '#theme' => 'oe_theme_helper_address_inline',
+      '#address' => $address,
+      '#address_items' => $values,
+      '#address_delimiter' => $this->getSetting('delimiter'),
+      '#cache' => [
+        'contexts' => [
+          'languages:' . LanguageInterface::TYPE_INTERFACE,
+        ],
+      ],
+    ];
+  }
+
+  /**
+   * Gets the address values used for rendering.
+   *
+   * @param \Drupal\address\AddressInterface $address
+   *   The address.
+   * @param \CommerceGuys\Addressing\AddressFormat\AddressFormat $address_format
+   *   The address format.
+   *
+   * @return array
+   *   The values, keyed by address field.
+   */
+  protected function getValues(AddressInterface $address, AddressFormat $address_format) {
+    $values = [];
+    foreach (AddressField::getAll() as $field) {
+      $getter = 'get' . ucfirst($field);
+      $values[$field] = $address->$getter();
+    }
+
+    $original_values = [];
+    $subdivision_fields = $address_format->getUsedSubdivisionFields();
+    $parents = [];
+    foreach ($subdivision_fields as $index => $field) {
+      $value = $values[$field];
+      if (empty($value)) {
+        unset($values[$field]);
+        break;
+      }
+      $parents[] = $index ? $original_values[$subdivision_fields[$index - 1]] : $address->getCountryCode();
+      $subdivision = $this->subdivisionRepository->get($value, $parents);
+      if (!$subdivision) {
+        break;
+      }
+
+      // Remember the original value so that it can be used for $parents.
+      $original_values[$field] = $value;
+      // Replace the value with the expected code.
+      if (Locale::matchCandidates($address->getLocale(), $subdivision->getLocale())) {
+        $values[$field] = $subdivision->getLocalCode();
+      }
+      else {
+        $values[$field] = $subdivision->getCode();
+      }
+
+      if (!$subdivision->hasChildren()) {
+        // The current subdivision has no children, stop.
+        break;
+      }
+    }
+
+    return $values;
+  }
+
+}

--- a/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
+++ b/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file
+ * Default template for the 'oe_theme_helper_address_inline' address formatter.
+ *
+ * Available variables:
+ *   - address: Address object.
+ *   - address_items: Address items.
+ *   - address_delimiter: Delimiter between address items.
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set ordered_address = [
+  address_items.addressLine1,
+  address_items.addressLine2,
+  address_items.postalCode,
+  address_items.locality,
+]
+%}
+<p class="address" translate="no">
+  {{ ordered_address|filter(v => v is not empty)|join(address_delimiter) }}
+</p>

--- a/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
+++ b/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
@@ -11,16 +11,6 @@
  * @ingroup themeable
  */
 #}
-{%
-  set ordered_address = []
-%}
-
-{% for address_elem in ['addressLine1', 'addressLine2', 'postalCode', 'locality'] %}
-  {% if address_items[address_elem] %}
-    {% set ordered_address = ordered_address|merge([address_items[address_elem]]) %}
-  {% endif %}
-{% endfor %}
-
 <p class="address" translate="no">
-  {{ ordered_address|join(address_delimiter) }}
+  {{ address_items|join(address_delimiter) }}
 </p>

--- a/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
+++ b/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
@@ -12,13 +12,15 @@
  */
 #}
 {%
-  set ordered_address = [
-  address_items.addressLine1,
-  address_items.addressLine2,
-  address_items.postalCode,
-  address_items.locality,
-]
+  set ordered_address = []
 %}
+
+{% for address_elem in ['addressLine1', 'addressLine2', 'postalCode', 'locality'] %}
+  {% if address_items[address_elem] %}
+    {% set ordered_address = ordered_address|merge([address_items[address_elem]]) %}
+  {% endif %}
+{% endfor %}
+
 <p class="address" translate="no">
-  {{ ordered_address|filter(v => v is not empty)|join(address_delimiter) }}
+  {{ ordered_address|join(address_delimiter) }}
 </p>

--- a/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
+++ b/modules/oe_theme_helper/templates/oe-theme-helper-address-inline.html.twig
@@ -11,6 +11,6 @@
  * @ingroup themeable
  */
 #}
-<p class="address" translate="no">
+<span translate="no">
   {{ address_items|join(address_delimiter) }}
-</p>
+</span>

--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme_helper\Kernel\Plugin\Field\FieldFormatter;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\Tests\address\Kernel\Formatter\FormatterTestBase;
+
+/**
+ * Test AddressInlineFormatter plugin.
+ */
+class AddressInlineFormatterTest extends FormatterTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'oe_theme_helper',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    $this->createField('address', 'oe_theme_helper_address_inline');
+  }
+
+  /**
+   * Tests formatting of address.
+   */
+  public function testInlineFormatterAddress() {
+    $entity = EntityTest::create([]);
+    $entity->{$this->fieldName} = [
+      'country_code' => 'BE',
+      'locality' => 'Brussels',
+      'postal_code' => '1000',
+      'address_line1' => 'Rue de la Loi, 56',
+    ];
+
+    $this->renderEntityFields($entity, $this->display);
+    $expected = 'Rue de la Loi, 56, 1000, Brussels';
+    $this->assertRaw($expected);
+  }
+
+}

--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
@@ -40,7 +40,7 @@ class AddressInlineFormatterTest extends FormatterTestBase {
     ];
 
     $this->renderEntityFields($entity, $this->display);
-    $expected = 'Rue de la Loi, 56, 1000, Brussels';
+    $expected = 'Rue de la Loi, 56, 1000 Brussels, Belgium';
     $this->assertRaw($expected);
   }
 


### PR DESCRIPTION
## OPENEUROPA-2642

### Description

It turned out that the address_plain formatter does not pass the entity to the theme function, making it impossible to create the proper suggestions. The only option left here is to create a custom formatter for the address field that will allow us to configure a separator and will print the address simply separated by that, like: Rue de la Loi, 56, 1000, Brussels.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

