### PR TITLE
OPENEUROPA-2753: Load oe_theme libraries in sub-themes.

### DIFF
--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -29,7 +29,8 @@ function oe_theme_helper_page_attachments(array &$page) {
   }
 
   // Load ECL component library assets.
-  if (\Drupal::service('theme.manager')->getActiveTheme()->getName() === 'oe_theme') {
+  $active_theme = \Drupal::service('theme.manager')->getActiveTheme();
+  if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemes())) {
     $page['#attached']['library'][] = 'oe_theme/component_library_' . theme_get_setting('component_library');
   }
 }

--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -31,7 +31,7 @@ function oe_theme_helper_page_attachments(array &$page) {
   // Load ECL component library assets.
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme();
   // Loading libraries when active theme is oe_theme or oe_theme's child.
-  if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemes())) {
+  if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', array_keys($active_theme->getBaseThemeExtensions()))) {
     $page['#attached']['library'][] = 'oe_theme/component_library_' . theme_get_setting('component_library');
   }
 }

--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -31,7 +31,7 @@ function oe_theme_helper_page_attachments(array &$page) {
   // Load ECL component library assets.
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme();
   // Loading libraries when active theme is oe_theme or oe_theme's child.
-  if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', array_keys($active_theme->getBaseThemeExtensions()))) {
+  if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemeExtensions())) {
     $page['#attached']['library'][] = 'oe_theme/component_library_' . theme_get_setting('component_library');
   }
 }

--- a/modules/oe_theme_helper/oe_theme_helper.module
+++ b/modules/oe_theme_helper/oe_theme_helper.module
@@ -30,6 +30,7 @@ function oe_theme_helper_page_attachments(array &$page) {
 
   // Load ECL component library assets.
   $active_theme = \Drupal::service('theme.manager')->getActiveTheme();
+  // Loading libraries when active theme is oe_theme or oe_theme's child.
   if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemes())) {
     $page['#attached']['library'][] = 'oe_theme/component_library_' . theme_get_setting('component_library');
   }


### PR DESCRIPTION
## OPENEUROPA-ISSUE-409
### Description

Added second condition using php array_key_exists('oe_theme', $active_theme->getBaseThemes())

### Change log

- Added: Child theme condition
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:


