### PR TITLE
OPENEUROPA-2771: Use SocialMediaLinksFormatter for social media field in Contact entity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.0.0-beta4",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "dev-OPENEUROPA-2771",
+        "openeuropa/oe_content": "dev-EPIC-Event",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_media": "dev-master",
         "openeuropa/oe_multilingual": "~1.0",
@@ -91,6 +91,9 @@
         "patches": {
             "drupal/drupal-driver": {
                 "allow-date-only-date-fields": "https://patch-diff.githubusercontent.com/raw/jhedstrom/DrupalDriver/pull/201.patch"
+            },
+            "openeuropa/oe_content": {
+                "latest-master": "https://github.com/openeuropa/oe_content/compare/EPIC-Event...OPENEUROPA-2771.diff"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -91,9 +91,6 @@
         "patches": {
             "drupal/drupal-driver": {
                 "allow-date-only-date-fields": "https://patch-diff.githubusercontent.com/raw/jhedstrom/DrupalDriver/pull/201.patch"
-            },
-            "openeuropa/oe_content": {
-                "latest-master": "https://github.com/openeuropa/oe_content/compare/EPIC-Event...OPENEUROPA-2771.diff"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.0.0-beta4",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "dev-EPIC-Event",
+        "openeuropa/oe_content": "dev-OPENEUROPA-2771",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_media": "dev-master",
         "openeuropa/oe_multilingual": "~1.0",

--- a/modules/oe_theme_content_entity_contact/config/overrides/core.entity_view_display.oe_contact.oe_general.default.yml
+++ b/modules/oe_theme_content_entity_contact/config/overrides/core.entity_view_display.oe_contact.oe_general.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.oe_contact.oe_general.oe_address
     - field.field.oe_contact.oe_general.oe_email
     - field.field.oe_contact.oe_general.oe_phone
+    - field.field.oe_contact.oe_general.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_general
   module:
     - address
@@ -53,6 +54,20 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: oe_theme_helper_social_media_links_formatter
+    weight: 5
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      rel: nofollow
+      target: _blank
+      title: 'Social media'
+      variant: horizontal
+      url_only: false
+      url_plain: false
+    third_party_settings: {  }
 hidden:
   created: true
   langcode: true

--- a/modules/oe_theme_content_entity_contact/config/overrides/core.entity_view_display.oe_contact.oe_press.default.yml
+++ b/modules/oe_theme_content_entity_contact/config/overrides/core.entity_view_display.oe_contact.oe_press.default.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.field.oe_contact.oe_press.oe_address
     - field.field.oe_contact.oe_press.oe_email
     - field.field.oe_contact.oe_press.oe_phone
+    - field.field.oe_contact.oe_press.oe_social_media
     - oe_content_entity_contact.oe_contact_type.oe_press
   module:
     - address
@@ -62,6 +63,20 @@ content:
     third_party_settings: {  }
     type: string
     region: content
+  oe_social_media:
+    type: oe_theme_helper_social_media_links_formatter
+    weight: 4
+    region: content
+    label: hidden
+    settings:
+      trim_length: 80
+      rel: nofollow
+      target: _blank
+      title: 'Social media'
+      variant: horizontal
+      url_only: false
+      url_plain: false
+    third_party_settings: {  }
 hidden:
   created: true
   langcode: true

--- a/templates/field/field--oe-contact--oe-social-media.html.twig
+++ b/templates/field/field--oe-contact--oe-social-media.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for the field template.
+ *
+ * @see ./core/themes/stable/templates/field/field.html.twig
+ */
+#}
+<div class="ecl-u-mt-l">
+  {% for item in items %}
+    {{- item.content -}}
+  {% endfor %}
+</div>

--- a/tests/features/event.feature
+++ b/tests/features/event.feature
@@ -139,15 +139,17 @@ Feature: Event content type.
       | Email        | press1@example.com                                                                       |
       | Phone number | +32477777777                                                                             |
     And the following Press Contact entity:
-      | Name         | Second press contact                                                                     |
-      | Address      | country_code: HU - locality: Szeged - address_line1: Press contact 1 - postal_code: 6700 |
-      | Email        | press2@example.com                                                                       |
-      | Phone number | +32477777778                                                                             |
+      | Name               | Second press contact                                                                     |
+      | Address            | country_code: HU - locality: Szeged - address_line1: Press contact 1 - postal_code: 6700 |
+      | Email              | press2@example.com                                                                       |
+      | Phone number       | +32477777778                                                                             |
+      | Social media links | uri: http://facebook.com - title: Facebook - link_type: facebook                         |
     And the following General Contact entity:
-      | Name         | A general contact                                                                        |
-      | Address      | country_code: HU - locality: Budapest - address_line1: General contact 1 - postal_code: 1011 |
-      | Email        | general@example.com                                                                          |
-      | Phone number | +32477792933                                                                                 |
+      | Name               | A general contact                                                                            |
+      | Address            | country_code: HU - locality: Budapest - address_line1: General contact 1 - postal_code: 1011 |
+      | Email              | general@example.com                                                                          |
+      | Phone number       | +32477792933                                                                                 |
+      | Social media links | uri: http://instagram.com - title: Instagram - link_type: instagram                          |
     And the Event Content "Event demo page" is updated as follows:
       | Venue   | DIGIT                                                        |
       | Contact | First press contact, Second press contact, A general contact |
@@ -169,6 +171,7 @@ Feature: Event content type.
     And I should see "Address"
     And I should see "Budapest, General contact 1, 1011, Hungary"
     And I should see "general@example.com"
+    And I should see the link "Instagram" in the "event contacts"
 
     And I should see the heading "Press contact" in the "event contacts"
     And I should see "Name"
@@ -182,6 +185,7 @@ Feature: Event content type.
     And I should see "+32477777778"
     And I should see "Szeged, Press contact 1, 6700, Hungary"
     And I should see "press2@example.com"
+    And I should see the link "Facebook" in the "event contacts"
 
     # Assert remaining event elements.
     Given the following image:


### PR DESCRIPTION
## OPENEUROPA-2771

### Description

Use SocialMediaLinksFormatter for social media field in Contact entity.

### Change log

- Added: theme social media field in Contact entity
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh

```

