### PR TITLE
OPENEUROPA-2809: Add Ratio 3:2 medium image style.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0.0-beta4",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "~1.4",
+        "openeuropa/oe_content": "~1.6",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_media": "~1.0",
         "openeuropa/oe_multilingual": "~1.0",

--- a/config/install/image.style.oe_theme_ratio_3_2_medium.yml
+++ b/config/install/image.style.oe_theme_ratio_3_2_medium.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies: {  }
+name: oe_theme_ratio_3_2_medium
+label: 'Ratio 3:2 medium'
+effects:
+  5796bb6b-8278-4b53-b64e-080696536311:
+    uuid: 5796bb6b-8278-4b53-b64e-080696536311
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 600
+      height: 400
+      anchor: center-center

--- a/modules/oe_theme_helper/oe_theme_helper.post_update.php
+++ b/modules/oe_theme_helper/oe_theme_helper.post_update.php
@@ -139,7 +139,13 @@ function oe_theme_helper_post_update_20006() {
 /**
  * Add Ratio 3:2 medium image style.
  */
-function oe_theme_helper_post_update_20007(array &$sandbox): void {
+function oe_theme_helper_post_update_20007(array &$sandbox) {
+  // If the image style already exists, we bail out.
+  $style = \Drupal::entityTypeManager()->getStorage('image_style')->load('oe_theme_ratio_3_2_medium');
+  if ($style) {
+    return 'The image style was previously created.';
+  }
+
   // Create image style.
   $image_style = ImageStyle::create([
     'name' => 'oe_theme_ratio_3_2_medium',

--- a/modules/oe_theme_helper/oe_theme_helper.post_update.php
+++ b/modules/oe_theme_helper/oe_theme_helper.post_update.php
@@ -135,3 +135,29 @@ function oe_theme_helper_post_update_20006() {
     $config_factory->getEditable($block)->save();
   }
 }
+
+/**
+ * Add Ratio 3:2 medium image style.
+ */
+function oe_theme_helper_post_update_20007(array &$sandbox): void {
+  // Create image style.
+  $image_style = ImageStyle::create([
+    'name' => 'oe_theme_ratio_3_2_medium',
+    'label' => 'Ratio 3:2 medium',
+  ]);
+
+  // Create effect.
+  $effect = [
+    'id' => 'image_scale_and_crop',
+    'weight' => 1,
+    'data' => [
+      'anchor' => 'center-center',
+      'width' => '600',
+      'height' => '400',
+    ],
+  ];
+
+  // Add effect to the image style and save.
+  $image_style->addImageEffect($effect);
+  $image_style->save();
+}

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -12,6 +12,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
+use Drupal\media\MediaInterface;
 use Drupal\media\Plugin\media\Source\Image;
 use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface;
 use Drupal\oe_theme\ValueObject\FileValueObject;
@@ -912,6 +913,10 @@ function oe_theme_preprocess_paragraph__oe_text_feature_media(array &$variables)
 
   /** @var \Drupal\media\Entity\Media $media */
   $media = $paragraph->get('field_oe_media')->entity;
+  if (!$media instanceof MediaInterface) {
+    // The media entity is not available anymore, bail out.
+    return;
+  }
   // Caches are handled by the formatter usually. Since we are not rendering
   // the original render arrays, we need to propagate our caches to the
   // paragraph template.
@@ -925,11 +930,9 @@ function oe_theme_preprocess_paragraph__oe_text_feature_media(array &$variables)
   }
 
   $thumbnail = $media->get('thumbnail')->first();
-  $image = $thumbnail->get('entity')->getTarget();
-  $uri = $image->get('uri')->getString();
-  $style = \Drupal::entityTypeManager()->getStorage('image_style')->load('oe_theme_medium_no_crop');
+  $object = ImageValueObject::fromStyledImageItem($thumbnail, 'oe_theme_medium_no_crop');
   $variables['image'] = [
-    'src' => file_create_url($style->buildUrl($uri)),
+    'src' => $object['src'],
     'alt' => $thumbnail->alt,
   ];
 

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -930,11 +930,7 @@ function oe_theme_preprocess_paragraph__oe_text_feature_media(array &$variables)
   }
 
   $thumbnail = $media->get('thumbnail')->first();
-  $object = ImageValueObject::fromStyledImageItem($thumbnail, 'oe_theme_medium_no_crop');
-  $variables['image'] = [
-    'src' => $object['src'],
-    'alt' => $thumbnail->alt,
-  ];
+  $variables['image'] = ImageValueObject::fromStyledImageItem($thumbnail, 'oe_theme_medium_no_crop');
 
   $cacheability->applyTo($variables);
 }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -12,7 +12,6 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Url;
-use Drupal\media\Entity\MediaType;
 use Drupal\media\Plugin\media\Source\Image;
 use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface;
 use Drupal\oe_theme\ValueObject\FileValueObject;
@@ -925,25 +924,13 @@ function oe_theme_preprocess_paragraph__oe_text_feature_media(array &$variables)
     return;
   }
 
-  // If it's a media source we support, fetch the required data.
-  $media_type = MediaType::load($media->bundle());
-  $source_field = $source->getSourceFieldDefinition($media_type);
-  $field_name = $source_field->getName();
-  $source_value = $source->getSourceFieldValue($media);
-
-  if ($source instanceof MediaAvPortalSourceInterface) {
-    $uri = 'avportal://' . $source_value . '.jpg';
-  }
-
-  if ($source instanceof Image) {
-    /** @var \Drupal\file\Entity\File $file */
-    $file = $media->get($field_name)->entity;
-    $uri = $file->getFileUri();
-    $cacheability->addCacheableDependency($file);
-  }
+  $thumbnail = $media->get('thumbnail')->first();
+  $image = $thumbnail->get('entity')->getTarget();
+  $uri = $image->get('uri')->getString();
+  $style = \Drupal::entityTypeManager()->getStorage('image_style')->load('oe_theme_medium_no_crop');
   $variables['image'] = [
-    'src' => file_create_url($uri),
-    'alt' => $media->get($field_name)->alt,
+    'src' => file_create_url($style->buildUrl($uri)),
+    'alt' => $thumbnail->alt,
   ];
 
   $cacheability->applyTo($variables);

--- a/src/ValueObject/ImageValueObject.php
+++ b/src/ValueObject/ImageValueObject.php
@@ -144,4 +144,25 @@ class ImageValueObject extends ValueObjectBase {
     );
   }
 
+  /**
+   * Construct object from a styled image.
+   *
+   * @param \Drupal\image\Plugin\Field\FieldType\ImageItem $image_item
+   *   Field holding the image.
+   * @param string $style
+   *   The style.
+   *
+   * @return $this
+   */
+  public static function fromStyledImageItem(ImageItem $image_item, string $style): ValueObjectInterface {
+    $image_file = $image_item->get('entity')->getTarget();
+    $style = \Drupal::entityTypeManager()->getStorage('image_style')->load($style);
+
+    return new static(
+      $style->buildUrl($image_file->get('uri')->getString()),
+      $image_item->get('alt')->getString(),
+      $image_item->get('title')->getString()
+    );
+  }
+
 }

--- a/src/ValueObject/ImageValueObject.php
+++ b/src/ValueObject/ImageValueObject.php
@@ -145,7 +145,7 @@ class ImageValueObject extends ValueObjectBase {
   }
 
   /**
-   * Construct object from a styled image.
+   * Construct object from a Drupal image field after styling the image.
    *
    * @param \Drupal\image\Plugin\Field\FieldType\ImageItem $image_item
    *   Field holding the image.

--- a/src/ValueObject/ImageValueObject.php
+++ b/src/ValueObject/ImageValueObject.php
@@ -145,18 +145,26 @@ class ImageValueObject extends ValueObjectBase {
   }
 
   /**
-   * Construct object from a Drupal image field after styling the image.
+   * Construct object from a Drupal image field and image style.
    *
    * @param \Drupal\image\Plugin\Field\FieldType\ImageItem $image_item
-   *   Field holding the image.
-   * @param string $style
-   *   The style.
+   *   The field image item instance.
+   * @param string $style_name
+   *   The image style name.
    *
    * @return $this
+   *   A image value object instance.
+   *
+   * @throws \InvalidArgumentException
+   *   Thrown when the image style is not found.
    */
-  public static function fromStyledImageItem(ImageItem $image_item, string $style): ValueObjectInterface {
+  public static function fromStyledImageItem(ImageItem $image_item, string $style_name): ValueObjectInterface {
     $image_file = $image_item->get('entity')->getTarget();
-    $style = \Drupal::entityTypeManager()->getStorage('image_style')->load($style);
+
+    $style = \Drupal::entityTypeManager()->getStorage('image_style')->load($style_name);
+    if (!$style) {
+      throw new \InvalidArgumentException(sprintf('Could not load image style with name "%s".', $style_name));
+    }
 
     return new static(
       $style->buildUrl($image_file->get('uri')->getString()),

--- a/tests/Kernel/Paragraphs/MediaParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/MediaParagraphsTest.php
@@ -138,6 +138,7 @@ class MediaParagraphsTest extends ParagraphsTestBase {
     // referenced media but the caption is no longer rendered.
     $image = $figure->filter('.ecl-media-container__media');
     $this->assertContains('/example_1.jpeg', $image->attr('src'));
+    $this->assertContains('oe_theme_medium_no_crop', $image->attr('src'));
     $this->assertContains('Alt', $image->attr('alt'));
     $caption = $figure->filter('.ecl-media-container__caption');
     $this->assertCount(0, $caption);

--- a/tests/Kernel/Paragraphs/MediaParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/MediaParagraphsTest.php
@@ -137,7 +137,6 @@ class MediaParagraphsTest extends ParagraphsTestBase {
     // The image in the figure element has the source and alt defined in the
     // referenced media but the caption is no longer rendered.
     $image = $figure->filter('.ecl-media-container__media');
-    $this->assertContains('/example_1.jpeg', $image->attr('src'));
     $this->assertContains('/styles/oe_theme_medium_no_crop/public/example_1.jpeg', $image->attr('src'));
     $this->assertContains('Alt', $image->attr('alt'));
     $caption = $figure->filter('.ecl-media-container__caption');

--- a/tests/Kernel/Paragraphs/MediaParagraphsTest.php
+++ b/tests/Kernel/Paragraphs/MediaParagraphsTest.php
@@ -138,7 +138,7 @@ class MediaParagraphsTest extends ParagraphsTestBase {
     // referenced media but the caption is no longer rendered.
     $image = $figure->filter('.ecl-media-container__media');
     $this->assertContains('/example_1.jpeg', $image->attr('src'));
-    $this->assertContains('oe_theme_medium_no_crop', $image->attr('src'));
+    $this->assertContains('/styles/oe_theme_medium_no_crop/public/example_1.jpeg', $image->attr('src'));
     $this->assertContains('Alt', $image->attr('alt'));
     $caption = $figure->filter('.ecl-media-container__caption');
     $this->assertCount(0, $caption);

--- a/tests/Kernel/ValueObject/ImageTest.php
+++ b/tests/Kernel/ValueObject/ImageTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\Kernel\ValueObject;
+
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\file\Entity\File;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\oe_theme\ValueObject\ImageValueObject;
+use Drupal\Tests\token\Kernel\KernelTestBase;
+
+/**
+ * Test image value object with image field type.
+ */
+class ImageTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'image',
+    'file',
+    'entity_test',
+    'field',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $this->installEntitySchema('file');
+    $this->installEntitySchema('entity_test');
+
+    $this->installSchema('file', ['file_usage']);
+
+    $this->installConfig(['field', 'system']);
+
+    // Create a field with settings to validate.
+    $field_storage = FieldStorageConfig::create([
+      'entity_type' => 'entity_test',
+      'field_name' => 'field_image',
+      'type' => 'image',
+    ]);
+    $field_storage->save();
+    FieldConfig::create([
+      'field_storage' => $field_storage,
+      'bundle' => 'entity_test',
+    ])->save();
+
+    // Copy file in public files to use it for styling.
+    \Drupal::service('file_system')->copy(__DIR__ . '/../../fixtures/example_1.jpeg', 'public://example_1.jpg');
+  }
+
+  /**
+   * Test the image value object has the correct style applied.
+   */
+  public function testFromStyledImageItem() {
+    // Create image file.
+    $image = File::create([
+      'uri' => 'public://example_1.jpg',
+    ]);
+    $image->save();
+
+    // Create a test style.
+    /** @var \Drupal\image\ImageStyleInterface $style */
+    $style = ImageStyle::create(['name' => 'main_style']);
+    $style->save();
+
+    // Create an image item.
+    $alt = $this->randomMachineName();
+    $title = $this->randomMachineName();
+    $entity = EntityTest::create([
+      'name' => $this->randomString(),
+      'field_image' => [
+        'target_id' => $image->id(),
+        'alt' => $alt,
+        'title' => $title,
+      ],
+    ]);
+    $entity->save();
+
+    $object = ImageValueObject::fromStyledImageItem($entity->get('field_image')->first(), $style->getName());
+    $this->assertEquals($title, $object->getName());
+    $this->assertEquals($alt, $object->getAlt());
+    $this->assertContains('/styles/main_style/public/example_1.jpg', $object->getSource());
+  }
+
+}

--- a/tests/Kernel/ValueObject/ImageTest.php
+++ b/tests/Kernel/ValueObject/ImageTest.php
@@ -72,8 +72,8 @@ class ImageTest extends KernelTestBase {
     $style->save();
 
     // Create an image item.
-    $alt = $this->randomMachineName();
-    $title = $this->randomMachineName();
+    $alt = $this->randomString();
+    $title = $this->randomString();
     $entity = EntityTest::create([
       'name' => $this->randomString(),
       'field_image' => [
@@ -88,6 +88,10 @@ class ImageTest extends KernelTestBase {
     $this->assertEquals($title, $object->getName());
     $this->assertEquals($alt, $object->getAlt());
     $this->assertContains('/styles/main_style/public/example_1.jpg', $object->getSource());
+
+    $invalid_image_style = $this->randomMachineName();
+    $this->setExpectedException(\InvalidArgumentException::class, sprintf('Could not load image style with name "%s".', $invalid_image_style));
+    ImageValueObject::fromStyledImageItem($entity->get('field_image')->first(), $invalid_image_style);
   }
 
 }

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -32,7 +32,7 @@ Feature: News content type.
     And I click "Edit"
     And I fill in "Use existing media" with "My Image 1"
     # Introduce a short title.
-    And I fill in "Short title" with "Shorter title"
+    And I fill in "Alternative title" with "Shorter title"
     And I press "Save"
 
     When I am on "the recent content page"


### PR DESCRIPTION
## OPENEUROPA-2809

### Description

Creates new Ratio 3:2 medium image style and styles image of text with featured media paragraph using oe_theme_medium_no_crop style.

### Change log

- Added: oe_theme_ratio_3_2_medium image style
- Changed: 
- Deprecated:
- Removed:
- Fixed: image style of text with featured media paragraph
- Security:

### Commands

```sh

```

