### PR TITLE
SGECI2-370: Displaying wrong language (file entity not translatable).

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1109,7 +1109,8 @@ function oe_theme_preprocess_media__document__default(&$variables) {
   $media = $variables['media'];
   $file_object = $media->get('oe_media_file')->first()->entity;
   $variables['file'] = FileValueObject::fromFileEntity($file_object)
-    ->setTitle($media->getName());
+    ->setTitle($media->getName())
+    ->setLanguageCode($media->language()->getId());
 }
 
 /**


### PR DESCRIPTION
### Description

If a media type is translatable and we translate the file, it will be displayed wrongly the translated file language. File entity not translatable, so we need to use the media entity language to determine what language the file has.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed: oe_theme_preprocess_media__document__default
- Security:

### Commands

