### PR TITLE
OPENEUROPA-2821: Implement ECL pagination behavior for component.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -521,120 +521,163 @@ function oe_theme_preprocess_field(&$variables, $hook): void {
  *
  * @see template_preprocess_pager()
  *
- * Overwrites the default Drupal pager in order to adapt to the ECL style
- * guide pager component requirements.
- * Most of the bare-bones are copy-pasted from the Drupal implementation.
+ * Generates pagination items for ECL pagination component.
  */
 function oe_theme_preprocess_pager(array &$variables): void {
-  // Get the tags for the first, previous, next and last links.
-  $tags = $variables['pager']['#tags'];
+  $element = $variables['pager']['#element'];
+  $parameters = $variables['pager']['#parameters'];
+  $route_name = $variables['pager']['#route_name'];
+  $route_parameters = $variables['pager']['#route_parameters'] ?? [];
+  global $pager_page_array, $pager_total;
+  // Maximum page number for this pager.
+  $pager_max = $pager_total[$element];
+  // Nothing to do if there is only one page.
+  if ($pager_max <= 1) {
+    return;
+  }
+  // Max number of pages to display next to the current page (left/right).
+  // The first and last page links are excluded from this count.
+  $pager_offset = 2;
+  // The page we are currently paged to.
+  $pager_current = $pager_page_array[$element] + 1;
+  // First page of the pagination calculated by offset from current.
+  $pager_first = $pager_offset < $pager_current ? $pager_current - $pager_offset : 1;
+  // Last page of the pagination calculated by offset from current.
+  $pager_last = $pager_current + $pager_offset;
 
-  $variables['ecl_items'] = [];
+  // Remove extra pages if last page is larger than maximum.
+  if ($pager_last > $pager_max) {
+    $pager_last = $pager_max;
+  }
 
-  // Generate fist link if it is available.
-  if (!empty($variables['items']['first']['href'])) {
-    $first_link = [];
-    $first_link['type'] = 'first';
-    $first_link['aria_label'] = t('Go to first page');
-    $label = t('‹‹ First');
-    if (isset($tags[0])) {
-      $label = $tags[0];
+  // Array to collect the pagination items.
+  $ecl_items = [];
+
+  // Prepare navigation link item for previous/next links with defaults.
+  $nav_link = [
+    'link' => [
+      'icon' => [
+        'path' => $variables['ecl_icon_path'],
+        'type' => 'ui',
+        'name' => 'corner-arrow',
+        'size' => 'xs',
+        'transform' => 'rotate-270',
+      ],
+    ],
+  ];
+  // Prepare ellipsis item.
+  $ellipsis = [
+    'type' => 'ellipsis',
+    'label' => '...',
+  ];
+
+  // Add 'Previous' navigation link.
+  if ($pager_current > 1) {
+    $options = [
+      'query' => pager_query_add_page($parameters, $element, $pager_page_array[$element] - 1),
+    ];
+    $nav_link['link']['link'] = [
+      'path' => Url::fromRoute($route_name, $route_parameters, $options),
+      'label' => t('Previous'),
+      'icon_position' => 'before',
+    ];
+    $nav_link['type'] = 'previous';
+    $nav_link['aria_label'] = t('Go to previous page');
+    $ecl_items[] = $nav_link;
+  }
+
+  // Add first page link.
+  if ($pager_first != $pager_current) {
+    $options = [
+      'query' => pager_query_add_page($parameters, $element, 0),
+    ];
+    $ecl_items[] = [
+      'type' => 'first',
+      'link' => [
+        'link' => [
+          'path' => Url::fromRoute($route_name, $route_parameters, $options),
+          'label' => '1',
+        ],
+      ],
+      'aria_label' => t('Go to page @number', ['@number' => 1]),
+    ];
+  }
+
+  // Add first ellipsis.
+  if ($pager_current - $pager_offset > 2) {
+    $ecl_items[] = $ellipsis;
+  }
+
+  // Generate page link items.
+  $i = $pager_first;
+  for (; $i <= $pager_current + $pager_offset && $i <= $pager_last; $i++) {
+    $label = (string) $i;
+    if ($i == $pager_current) {
+      $ecl_items[] = [
+        'type' => 'current',
+        'label' => $label,
+        'aria_label' => t('Page @number', ['@number' => $label]),
+      ];
     }
-    $first_link['link']['link'] = [
-      'path' => $variables['items']['first']['href'],
-      'label' => $label,
-    ];
-    $variables['ecl_items'][] = $first_link;
-  }
-
-  // Generate previous link if it is available.
-  if (!empty($variables['items']['previous']['href'])) {
-    $previous_link = [];
-    $previous_link['type'] = 'previous';
-    $previous_link['aria_label'] = t('Go to previous page');
-    $label = t('‹ Previous');
-    if (isset($tags[1])) {
-      $label = $tags[1];
-    }
-    $previous_link['link']['link'] = [
-      'path' => $variables['items']['previous']['href'],
-      'label' => $label,
-    ];
-    $variables['ecl_items'][] = $previous_link;
-  }
-
-  // Generate previous ellipses if needed.
-  if (isset($variables['ellipses']['previous']) && $variables['ellipses']['previous']) {
-    $ellipsis = [
-      'type' => 'ellipsis',
-      'label' => '...',
-    ];
-    $variables['ecl_items'][] = $ellipsis;
-  }
-
-  // Generate actual pager items.
-  if (!empty($variables['items']['pages'])) {
-    foreach ($variables['items']['pages'] as $page_key => $page_item) {
-      if ($page_key == $variables['current']) {
-        $current_link = [
-          'type' => 'current',
-          'aria_label' => t('Page @number', ['@number' => $page_key]),
-          'label' => (string) $page_key,
-        ];
-        $variables['ecl_items'][] = $current_link;
+    else {
+      // Skip first or last page.
+      if ($i == 1 || $i == $pager_max) {
         continue;
       }
-      $link = [];
-      $link['aria_label'] = t('Go to page @number', ['@number' => $page_key]);
-      $link['link']['link'] = [
-        'path' => $page_item['href'],
-        'label' => (string) $page_key,
+      $options = [
+        'query' => pager_query_add_page($parameters, $element, $i - 1),
       ];
-      $variables['ecl_items'][] = $link;
+      $ecl_items[] = [
+        'link' => [
+          'link' => [
+            'path' => Url::fromRoute($route_name, $route_parameters, $options),
+            'label' => $label,
+          ],
+        ],
+        'aria_label' => t('Go to page @number', ['@number' => $i]),
+      ];
     }
   }
 
-  // Generate next ellipses if needed.
-  if (isset($variables['ellipses']['next']) && $variables['ellipses']['next']) {
-    $ellipsis = [
-      'type' => 'ellipsis',
-      'label' => '...',
-    ];
-    $variables['ecl_items'][] = $ellipsis;
+  // Add second ellipsis.
+  if ($pager_last < $pager_max - 1) {
+    $ecl_items[] = $ellipsis;
   }
 
-  // Generate next link if it is available.
-  if (!empty($variables['items']['next']['href'])) {
-    $first_link = [];
-    $first_link['type'] = 'next';
-    $first_link['aria_label'] = t('Go to next page');
-    $label = t('Next ›');
-    if (isset($tags[3])) {
-      $label = $tags[3];
-    }
-    $first_link['link']['link'] = [
-      'path' => $variables['items']['next']['href'],
-      'label' => $label,
+  // Add last page link.
+  if ($pager_max != $pager_current) {
+    $options = [
+      'query' => pager_query_add_page($parameters, $element, $pager_max - 1),
     ];
-    $variables['ecl_items'][] = $first_link;
+    $ecl_items[] = [
+      'type' => 'last',
+      'link' => [
+        'link' => [
+          'path' => Url::fromRoute($route_name, $route_parameters, $options),
+          'label' => (string) $pager_max,
+        ],
+      ],
+      'aria_label' => t('Go to page @number', ['@number' => $pager_max]),
+    ];
   }
 
-  // Generate previous link if it is available.
-  if (!empty($variables['items']['last']['href'])) {
-    $last_link = [];
-    $last_link['type'] = 'last';
-    $last_link['aria_label'] = t('Go to last page');
-    $label = t('Last ››');
-    if (isset($tags[4])) {
-      $label = $tags[4];
-    }
-    $last_link['link']['link'] = [
-      'path' => $variables['items']['last']['href'],
-      'label' => $label,
+  // Add 'Next' navigation link.
+  if ($pager_current < $pager_max) {
+    $options = [
+      'query' => pager_query_add_page($parameters, $element, $pager_page_array[$element] + 1),
     ];
-    $variables['ecl_items'][] = $last_link;
+    $nav_link['link']['link'] = [
+      'path' => Url::fromRoute($route_name, $route_parameters, $options),
+      'label' => t('Next'),
+      'icon_position' => 'after',
+    ];
+    $nav_link['type'] = 'next';
+    $nav_link['aria_label'] = t('Go to next page');
+    $nav_link['link']['icon']['transform'] = 'rotate-90';
+    $ecl_items[] = $nav_link;
   }
-
+  $variables['label'] = t('Pagination');
+  $variables['ecl_items'] = $ecl_items;
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -609,8 +609,7 @@ function oe_theme_preprocess_pager(array &$variables): void {
   }
 
   // Generate page link items.
-  $i = $pager_first;
-  for (; $i <= $pager_current + $pager_offset && $i <= $pager_last; $i++) {
+  for ($i = $pager_first; $i <= $pager_current + $pager_offset && $i <= $pager_last; $i++) {
     $label = (string) $i;
     if ($i == $pager_current) {
       $ecl_items[] = [

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -4,26 +4,13 @@
  * Theme override to display a pager.
  *
  * Available variables:
- * - items.previous: Page link for the previous page; not present on the first page
- * - item.first: Page link for the first page; not present on the first page of results.
- * - items.last: Page link for the last page; not present on the last page of results.
- * - item.next: Page link for the next page; not present on the last page of results.
- *   Each of the page link variables which are listed above contain following elements:
- *   - href: URL with appropriate query parameters.
- *   - text: The visible text used for the page link.
- *   - title: The text used for filling the 'title' property of a given tag.
- * - items.pages: List of the pager page links.
- *   The list is keyed with ordered page numbers and each item contatin following elements:
- *   - href: URL with appropriate query parameters.
- *   - text: The visible text used for the page link.
- *   - title: The text used for filling the 'title' property of a given tag.
- * - current: The page number of the current page.
- * - max_page: The total number of pages.
+ * - label: Label for pagination component.
+ * - ecl_items: List of pagination items prepared for ECL paginaton component.
  *
- * @see template_preprocess_pager()
+ * @see oe_theme_preprocess_pager()
  */
 #}
-{% if items %}
+{% if ecl_items %}
   {% include '@ecl-twig/pagination' with {
     'items': ecl_items,
   } %}

--- a/tests/Kernel/PagerTest.php
+++ b/tests/Kernel/PagerTest.php
@@ -17,14 +17,14 @@ class PagerTest extends AbstractKernelTestBase {
    *
    * @var string
    */
-  const PREVIOUS_PAGE_LINK_TEXT = '‹ Previous';
+  const PREVIOUS_PAGE_LINK_TEXT = 'Previous';
 
   /**
    * The 'next' page link text.
    *
    * @var string
    */
-  const NEXT_PAGE_LINK_TEXT = 'Next ›';
+  const NEXT_PAGE_LINK_TEXT = 'Next';
 
   /**
    * Test rendering of the pager.
@@ -69,7 +69,7 @@ class PagerTest extends AbstractKernelTestBase {
 
     // Check the first pager variant (all elements visible).
     $first_pager = $crawler->filter('nav:first-of-type');
-    // Assert that the pager contain 'first' and 'previous' page links.
+    // Assert that the pager contain 'next' and 'previous' page links.
     $previous = $first_pager->filter('li.ecl-pagination__item--previous');
     $this->assertSpecialPagerElement($previous, TRUE, $this->generatePagerUrl('<none>', 6), 'Go to previous page');
     $this->assertContains(self::PREVIOUS_PAGE_LINK_TEXT, $first_pager->text());
@@ -147,30 +147,18 @@ class PagerTest extends AbstractKernelTestBase {
     // By specifications, the following links should be visible:
     // - links to the previous two pages (if applicable);
     // - links to the next two pages (if applicable).
-    $pager_first = $current_page - 4;
-    $pager_last = $current_page + 4;
-
-    // Prepare for checking loop.
-    $i = $pager_first;
-    if ($pager_last > $total_pages) {
-      // Adjust "center" if at end of query.
-      $i = $i + ($total_pages - $pager_last);
-      $pager_last = $total_pages;
-    }
-    if ($i <= 0) {
-      // Adjust "center" if at start of query.
-      $pager_last = $pager_last + (1 - $i);
-      if ($pager_last > $total_pages) {
-        $pager_last = $total_pages;
-      }
-      $i = 1;
-    }
+    $min = $current_page - 2;
+    $max = $current_page + 2;
+    // Re-center the min and max pages values. Also don't test the first and
+    // last page links, as they are handled separately.
+    $min = $min < 2 ? 2 : $min;
+    $max = $max > ($total_pages - 1) ? $total_pages - 1 : $max;
 
     // Keep track of how many links should be visible.
     $links_count = 0;
 
     $links = $wrapper->filter('a');
-    for (; $i <= $pager_last; $i++) {
+    for ($i = $min; $i <= $max; $i++) {
       // The current page doesn't have a link.
       if ($i === $current_page) {
         continue;
@@ -197,7 +185,7 @@ class PagerTest extends AbstractKernelTestBase {
     $this->{$show_start_links ? 'assertContains' : 'assertNotContains'}(self::PREVIOUS_PAGE_LINK_TEXT, $crawler->html());
 
     $first_page = $crawler->filter('li.ecl-pagination__item--first');
-    $this->assertSpecialPagerElement($first_page, $show_start_links, $this->generatePagerUrl($route_name, 1), 'Go to first page');
+    $this->assertSpecialPagerElement($first_page, $show_start_links, $this->generatePagerUrl($route_name, 1), 'Go to page 1');
 
     // When the current page is not the last one, the link to the next page
     // and one to the last page should be shown.
@@ -210,20 +198,20 @@ class PagerTest extends AbstractKernelTestBase {
     $this->{$show_end_links ? 'assertContains' : 'assertNotContains'}(self::NEXT_PAGE_LINK_TEXT, $crawler->html());
 
     $last_page = $crawler->filter('li.ecl-pagination__item--last');
-    $this->assertSpecialPagerElement($last_page, $show_end_links, $this->generatePagerUrl($route_name, $total_pages), "Go to last page");
+    $this->assertSpecialPagerElement($last_page, $show_end_links, $this->generatePagerUrl($route_name, $total_pages), "Go to page $total_pages");
 
     // Verify that only the needed links have been rendered.
     $this->assertCount($links_count, $links);
 
     // Assert that ellipsis are shown in the correct number.
     $ellipsis = $wrapper->filter('li.ecl-pagination__item--ellipsis');
-    // When the total number of pages is 9 or less, no ellipsis should be shown.
+    // When the total number of pages is 4 or less, no ellipsis should be shown.
     $ellipsis_count = 0;
-    if ($total_pages > 9) {
-      // One ellipsis is shown when more than 4 pages are left at the end.
-      $ellipsis_count += (int) ($total_pages - $current_page) > 4;
-      // One ellipsis is shown when more than 4 pages have passed from the 1st.
-      $ellipsis_count += (int) ($current_page - 4) > 1;
+    if ($total_pages > 4) {
+      // One ellipsis is shown when more than 3 pages are left at the end.
+      $ellipsis_count += (int) ($total_pages - $current_page) > 3;
+      // One ellipsis is shown when more than 3 pages have passed from the 1st.
+      $ellipsis_count += (int) ($current_page - 3) > 1;
     }
     $this->assertCount($ellipsis_count, $ellipsis);
   }


### PR DESCRIPTION
## OPENEUROPA-2821

### Description
This PR implements the behavior for the pagination component required by ECL.

The pager behaviour was changed in 2.x version of the theme, compared to the 1.x version.
In 1.x the pager would show only the previous 2 and following 2 page links, plus the defined text.

### Change log

- Changed:
Updated pager preprocess logic to provide the correct pagination items for the component
Updated Pager test logic to test against the behavior implemented in 1.x
Updated comments in pager.html.twig template
