### PR TITLE
OPENEUROPA-3051: Use correct day format in date shown in news meta.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/styleguide": "~1.0-alpha3",
         "drush/drush": "~9.0",
         "easyrdf/easyrdf": "0.10.0-alpha.1 as 0.9.1",
+        "guzzlehttp/guzzle": "~6.3",
         "nikic/php-parser": "~3.0",
         "openeuropa/behat-transformation-context" : "~0.1",
         "openeuropa/code-review": "~1.0.0-beta4",

--- a/modules/oe_theme_content_news/config/install/core.date_format.oe_theme_news_date.yml
+++ b/modules/oe_theme_content_news/config/install/core.date_format.oe_theme_news_date.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: oe_theme_news_date
 label: 'News date'
 locked: false
-pattern: 'd F Y'
+pattern: 'j F Y'

--- a/modules/oe_theme_content_news/oe_theme_content_news.post_update.php
+++ b/modules/oe_theme_content_news/oe_theme_content_news.post_update.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * OpenEuropa theme News post updates.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Datetime\Entity\DateFormat;
+
+/**
+ * Add a date format for the News page header metadata.
+ */
+function oe_theme_content_news_post_update_00001(array &$sandbox): void {
+  $news_date_format = DateFormat::load('oe_theme_news_date');
+  $news_date_format->set('pattern', 'j F Y');
+  $news_date_format->save();
+}

--- a/modules/oe_theme_content_publication/config/install/core.date_format.oe_theme_publication_date.yml
+++ b/modules/oe_theme_content_publication/config/install/core.date_format.oe_theme_publication_date.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: oe_theme_publication_date
 label: 'Publication date'
 locked: false
-pattern: 'd F Y'
+pattern: 'j F Y'

--- a/modules/oe_theme_content_publication/oe_theme_content_publication.post_update.php
+++ b/modules/oe_theme_content_publication/oe_theme_content_publication.post_update.php
@@ -25,3 +25,12 @@ function oe_theme_content_publication_post_update_00001_add_publication_date_for
   $publication_date_format = DateFormat::create($date_format_values);
   $publication_date_format->save();
 }
+
+/**
+ * Update a date format for the Publication page header metadata.
+ */
+function oe_theme_content_publication_post_update_00002(array &$sandbox): void {
+  $news_date_format = DateFormat::load('oe_theme_publication_date');
+  $news_date_format->set('pattern', 'j F Y');
+  $news_date_format->save();
+}

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -38,7 +38,7 @@ Feature: News content type.
     When I am on "the recent content page"
     Then I should see the link "Shorter title"
     And I should see the text "News teaser"
-    And I should see the text "02 April 2019"
+    And I should see the text "2 April 2019"
     But I should not see the text "Full news title"
     And I should not see the text "Short summary"
     And I should not see the text "News body"

--- a/tests/features/news.feature
+++ b/tests/features/news.feature
@@ -13,7 +13,7 @@ Feature: News content type.
     When I am on "the recent content page"
     Then I should see the link "Full news title"
     And I should see the text "News teaser"
-    And I should see the text "02 April 2019"
+    And I should see the text "2 April 2019"
     But I should not see the text "Short summary"
     And I should not see the text "News body"
     And I should not see an "list item image" element

--- a/tests/features/page-header.feature
+++ b/tests/features/page-header.feature
@@ -66,7 +66,7 @@ Feature: Page header block component.
     # The default text format should be applied, converting URLs into links.
     And I should see the link "http://www.example.org" in the "page header intro"
     And I should see "News" in the "page header meta"
-    And I should see "02 April 2019" in the "page header meta"
+    And I should see "2 April 2019" in the "page header meta"
 
   Scenario: Policy content type has custom metadata shown in the page header.
     Given "oe_policy" content:
@@ -87,7 +87,7 @@ Feature: Page header block component.
     Then I should see the text "http://www.example.org is a web page" in the "page header intro"
     # The default text format should be applied, converting URLs into links.
     And I should see the link "http://www.example.org" in the "page header intro"
-    And I should see "02 April 2019" in the "page header meta"
+    And I should see "2 April 2019" in the "page header meta"
 
   Scenario: The page header block shows the content language switcher.
     Given the following "Spanish" translation for the "Robots are everywhere" demo page:


### PR DESCRIPTION
## OPENEUROPA-3051

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

