### PR TITLE
OPENEUROPA-2892: Add margin-top to ecl-file class.

### DIFF
--- a/sass/components/_wysiwyg.scss
+++ b/sass/components/_wysiwyg.scss
@@ -1,0 +1,5 @@
+.ecl-editor {
+  .ecl-file + .ecl-file {
+    margin-top: $ecl-spacing-xs;
+  }
+}

--- a/sass/style-ec.scss
+++ b/sass/style-ec.scss
@@ -4,3 +4,4 @@
 @import "./components/form";
 @import "./components/toolbar";
 @import "./components/banner";
+@import "./components/wysiwyg";

--- a/sass/style-eu.scss
+++ b/sass/style-eu.scss
@@ -8,3 +8,4 @@
 @import "./components/form";
 @import "./components/toolbar";
 @import "./components/banner";
+@import "./components/wysiwyg";


### PR DESCRIPTION
## OPENEUROPA-2892

### Description

Adds margin-top 0.5rem to ecl-file class when there are two consecutive ecl-file classes in an ecl-editor (usually in wysiwyg).

### Change log

- Added: margin-top to ecl-file class

