### PR TITLE
OPENEUROPA-3248: Add secondary links to navigation list.

### DIFF
--- a/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
+++ b/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
@@ -29,7 +29,7 @@
       {{ description }}
     </p>
   {% endif %}
-  {% if links is not empty and links is iterable %}
+  {% if links is not empty %}
     <ul class="ecl-u-mt-m ecl-unordered-list ecl-unordered-list--no-bullet">
       {% for link in links %}
         <li class="ecl-unordered-list__item">
@@ -38,8 +38,8 @@
       {% endfor %}
     </ul>
   {% endif %}
-  {% if secondary_links is not empty and secondary_links is iterable %}
-    <div class="ecl-u-mt-m ecl-u-border-top ecl-u-border-color-grey-50"">
+  {% if secondary_links is not empty %}
+    <div class="ecl-u-mt-m ecl-u-border-top ecl-u-border-color-grey-50">
       <ul class="ecl-u-mt-m ecl-unordered-list ecl-unordered-list--no-bullet">
         {% for link in secondary_links %}
           <li class="ecl-unordered-list__item">

--- a/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
+++ b/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
@@ -10,6 +10,7 @@
  * - "title_url" (string) (default: ''): url of the title.
  * - "description" (string) (default: ''): short description.
  * - "links" (array) (default: []): collection of standalone @ecl-twig/link items.
+ * - "secondary_links" (array) (default: []): secondary collection of standalone @ecl-twig/link items.
  */
 #}
 
@@ -36,6 +37,17 @@
         </li>
       {% endfor %}
     </ul>
+  {% endif %}
+  {% if secondary_links is not empty and secondary_links is iterable %}
+    <div class="ecl-u-mt-m ecl-u-border-top ecl-u-border-color-grey-50"">
+      <ul class="ecl-u-mt-m ecl-unordered-list ecl-unordered-list--no-bullet">
+        {% for link in secondary_links %}
+          <li class="ecl-unordered-list__item">
+            {% include '@ecl-twig/link' with { link: link.link|merge({type: 'standalone'}) } only %}
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   {% endif %}
 </div>
 {% endspaceless %}

--- a/templates/patterns/navigation_list/navigation_list.ui_patterns.yml
+++ b/templates/patterns/navigation_list/navigation_list.ui_patterns.yml
@@ -28,3 +28,12 @@ navigation_list:
           url: 'https://ec.europa.eu/info/education/policy-educational-issues/setting-objectives-and-measuring-progress_en'
         - label: 'International cooperation'
           url: 'https://ec.europa.eu/info/education/policy-educational-issues/international-cooperation_en'
+    secondary_links:
+      type: "array"
+      label: "Secondary Links"
+      description: "Secondary array of links that form the navigation list."
+      preview:
+        - label: 'Integrating migrants and refugees'
+          url: 'https://ec.europa.eu/info/education/policy-educational-issues/shared-challenges-education-and-training/integrating-migrants-and-refugees_en'
+        - label: 'Early school leaving'
+          url: 'https://ec.europa.eu/info/education/policy-educational-issues/shared-challenges-education-and-training/early-school-leaving_en'

--- a/templates/patterns/navigation_list/pattern-navigation-list.html.twig
+++ b/templates/patterns/navigation_list/pattern-navigation-list.html.twig
@@ -10,8 +10,7 @@
   {% set _link = {
     link: {
       label : link.label,
-      path : link.url,
-      type: 'standalone'
+      path : link.url
     }
   } %}
   {% set _links = _links|merge([_link]) %}
@@ -22,8 +21,7 @@
   {% set _secondary_link = {
     link: {
       label : secondary_link.label,
-      path : secondary_link.url,
-      type: 'standalone'
+      path : secondary_link.url
     }
   } %}
   {% set _secondary_links = _secondary_links|merge([_secondary_link]) %}

--- a/templates/patterns/navigation_list/pattern-navigation-list.html.twig
+++ b/templates/patterns/navigation_list/pattern-navigation-list.html.twig
@@ -17,9 +17,22 @@
   {% set _links = _links|merge([_link]) %}
 {% endfor %}
 
+{% set _secondary_links = [] %}
+{% for secondary_link in secondary_links %}
+  {% set _secondary_link = {
+    link: {
+      label : secondary_link.label,
+      path : secondary_link.url,
+      type: 'standalone'
+    }
+  } %}
+  {% set _secondary_links = _secondary_links|merge([_secondary_link]) %}
+{% endfor %}
+
 {% include '@oe_theme/compositions/ec-component-navigation-list/navigation-list.html.twig' with {
   title: title,
   title_url: title_url,
   description: description,
   links: _links,
+  secondary_links: _secondary_links,
 } only %}

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -1103,6 +1103,11 @@
           url: 'http://example.com/child2'
         - label: 'Child 3'
           url: 'http://example.com/child3'
+      secondary_links:
+        - label: 'Secondary Link 1'
+          url: 'http://example.com/secondary1'
+        - label: 'Secondary Link 2'
+          url: 'http://example.com/secondary2'
   assertions:
     equals:
       'h2.ecl-u-ma-none.ecl-u-type-prolonged-xl.ecl-u-type-bold a.ecl-link--standalone.ecl-link[href="http://example.com"]': 'Navigation list title'
@@ -1110,9 +1115,11 @@
       'li.ecl-unordered-list__item:nth-child(1) a.ecl-link[href="http://example.com/child1"]': 'Child 1'
       'li.ecl-unordered-list__item:nth-child(2) a.ecl-link[href="http://example.com/child2"]': 'Child 2'
       'li.ecl-unordered-list__item:nth-child(3) a.ecl-link[href="http://example.com/child3"]': 'Child 3'
+      'div.ecl-u-border-top li.ecl-unordered-list__item:nth-child(1) a.ecl-link[href="http://example.com/secondary1"]': 'Secondary Link 1'
+      'div.ecl-u-border-top li.ecl-unordered-list__item:nth-child(2) a.ecl-link[href="http://example.com/secondary2"]': 'Secondary Link 2'
     count:
-      ul.ecl-u-mt-m.ecl-unordered-list.ecl-unordered-list--no-bullet: 1
-      li.ecl-unordered-list__item: 3
+      ul.ecl-u-mt-m.ecl-unordered-list.ecl-unordered-list--no-bullet: 2
+      li.ecl-unordered-list__item: 5
 - array:
     '#type': pattern
     '#id': navigation_list
@@ -1127,6 +1134,7 @@
     count:
       ul.ecl-u-mt-m.ecl-unordered-list.ecl-unordered-list--no-bullet: 0
       li.ecl-unordered-list__item: 0
+      div.ecl-u-border-top: 0
 - array:
     '#type': pattern
     '#id': navigation_list
@@ -1150,6 +1158,7 @@
       ul.ecl-u-mt-m.ecl-unordered-list.ecl-unordered-list--no-bullet: 1
       li.ecl-unordered-list__item: 3
       'p.ecl-u-mb-none.ecl-u-mt-m.ecl-u-type-color-grey.ecl-u-type-paragraph': 0
+      div.ecl-u-border-top: 0
 - array:
     '#type': pattern
     '#id': page_header


### PR DESCRIPTION
## OPENEUROPA-3248
### Description

Add secondary links options to navigation list pattern.

### Change log

- Added: Secondary links to navigation list pattern.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

