### PR TITLE
OPENEUROPA-3282: Add oe_contact_forms integration.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "openeuropa/oe_paragraphs": "dev-master",
         "openeuropa/oe_search": "~1.0",
         "openeuropa/oe_webtools": "dev-master",
-        "openeuropa/oe_contact_forms": "dev-OPENEUROPA-3282B",
+        "openeuropa/oe_contact_forms": "dev-master",
         "openeuropa/task-runner": "^1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.4"

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "openeuropa/oe_paragraphs": "dev-master",
         "openeuropa/oe_search": "~1.0",
         "openeuropa/oe_webtools": "dev-master",
+        "openeuropa/oe_contact_forms": "dev-OPENEUROPA-3282B",
         "openeuropa/task-runner": "^1.0.0-beta5",
         "phpunit/phpunit": "~6.0",
         "symfony/dom-crawler": "~3.4"

--- a/modules/oe_theme_contact_forms/README.md
+++ b/modules/oe_theme_contact_forms/README.md
@@ -1,0 +1,15 @@
+# OpenEuropa Contact Forms companion module
+
+This module is a theming companion module to the [OpenEuropa Contact Forms](https://github.com/openeuropa/oe_contact_forms) module.
+It provides the logic needed to theme the corporate contact forms.
+
+## Installation
+
+Make sure you you have read the OpenEuropa Contact Forms's [README.md](https://github.com/openeuropa/oe_contact_forms/blob/master/README.md)
+before enabling this module.
+
+After enabling this module make sure you assign the following permissions to the anonymous user role, so visitors can
+correctly access corporate contact forms.
+
+- `Access corporate contact form`
+- `View published SKOS Concept entities`

--- a/modules/oe_theme_contact_forms/README.md
+++ b/modules/oe_theme_contact_forms/README.md
@@ -1,12 +1,11 @@
 # OpenEuropa Contact Forms companion module
 
-This module is a theming companion module to the [OpenEuropa Contact Forms](https://github.com/openeuropa/oe_contact_forms) module.
+This module is a theming companion module to the [OpenEuropa Contact Forms](https://github.com/openeuropa/oe_contact_forms) component.
 It provides the logic needed to theme the corporate contact forms.
 
 ## Installation
 
-Make sure you you have read the OpenEuropa Contact Forms's [README.md](https://github.com/openeuropa/oe_contact_forms/blob/master/README.md)
-before enabling this module.
+Make sure you have read the OpenEuropa Contact Forms's [README.md](https://github.com/openeuropa/oe_contact_forms/blob/master/README.md).
 
 After enabling this module make sure you assign the following permissions to the anonymous user role, so visitors can
 correctly access corporate contact forms.

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.info.yml
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.info.yml
@@ -1,0 +1,7 @@
+name: OpenEuropa Theme Contact Forms
+type: module
+description: Companion module for the OE Contact Forms module
+package: OpenEuropa
+core: 8.x
+dependencies:
+  - oe_contact_forms:oe_contact_forms

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -99,7 +99,7 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
     foreach ($fields as $field_name) {
       /** @var \Drupal\Core\Field\FieldItemList $field */
       $field = $contact_message->get($field_name);
-      if ($field->isEmpty() || !$field->access()){
+      if ($field->isEmpty() || !$field->access()) {
         continue;
       }
 

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -106,6 +106,11 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
       }
 
       $field_view = $field->view($display_settings);
+
+      if (!isset($field_view['#title'])) {
+        continue;
+      }
+
       $items[] = [
         'label' => $field_view['#title'],
         'body' => $field_view,

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -21,23 +21,29 @@ function oe_theme_contact_forms_form_contact_message_form_alter(&$form, FormStat
   /** @var \Drupal\contact\Entity\ContactForm $contact_form */
   $contact_form = ContactForm::load($contact_message->bundle());
 
+  $is_corporate_form = (boolean) $contact_form->getThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+  if (!$is_corporate_form) {
+    // We only care about the corporate contact forms.
+    return;
+  }
+
   // Display header as ecl paragraph.
-  $form['header']['#markup'] = '<p class="ecl-u-type-paragraph">' . $form['header']['#markup'] . '</p>';
-  // Logged in user name should display in its own line.
-  if ($form['name']['#type'] === 'item') {
-    $form['name']['#field_prefix'] = '<div class="ecl-u-mt-xs">';
-    $form['name']['#field_suffix'] = '</div>';
+  if (isset($form['header'])) {
+    $form['header'] = [
+      '#type' => 'inline_template',
+      '#template' => '<p class="ecl-u-type-paragraph">{{ header }}</p>',
+      '#context' => [
+        'header' => $form['header'],
+      ],
+    ];
   }
-  // Logged in user mail should display in its own line.
-  if ($form['mail']['#type'] === 'item') {
-    $form['mail']['#field_prefix'] = '<div class="ecl-u-mt-xs">';
-    $form['mail']['#field_suffix'] = '</div>';
-  }
+
   // Add ecl link classes to the privacy link.
   $privacy_link = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', FALSE);
   $privacy_title = t('I have read and agree with the <a class="ecl-u-ml-2xs ecl-link ecl-link--default" href="@link" target="_blank">data protection terms</a></label>', [
     '@link' => $privacy_link,
   ]);
+
   $form['privacy_policy']['#title'] = $privacy_title;
 }
 
@@ -50,7 +56,7 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
   }
 
   foreach ($variables['message_list']['status'] as $key => $value) {
-    // Target contact_messages.
+    // Target contact_messages which are being rendered in the status message.
     if (!is_array($value) || !isset($value['#contact_message'])) {
       continue;
     }
@@ -66,23 +72,15 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
       continue;
     }
 
-    $optional_selected = $contact_form->getThirdPartySetting('oe_contact_forms', 'optional_fields', []);
+    $optional_fields = $contact_form->getThirdPartySetting('oe_contact_forms', 'optional_fields', []);
     $items = [];
-    $fields = [
+    $fields = array_merge([
       'name',
       'mail',
       'subject',
       'message',
       'oe_topic',
-    ];
-
-    // Include the optional fields.
-    if (in_array('oe_country_residence', $optional_selected)) {
-      $fields[] = 'oe_country_residence';
-    }
-    if (in_array('oe_telephone', $optional_selected)) {
-      $fields[] = 'oe_telephone';
-    }
+    ], array_values($optional_fields));
 
     // Build the label body pairs for the field_list pattern.
     foreach ($fields as $field_name) {
@@ -90,7 +88,7 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
       $field = $contact_message->get($field_name);
       $display_settings = ['label' => 'hidden'];
 
-      if ($field_name == 'oe_country_residence') {
+      if ($field->getFieldDefinition()->getType() == 'skos_concept_entity_reference') {
         $display_settings = ['label' => 'hidden', 'settings' => ['link' => FALSE]];
       }
 

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * @file
+ * Module file used for theming the corporate contact forms.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\contact\Entity\ContactForm;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for contact_message_form().
+ */
+function oe_theme_contact_forms_form_contact_message_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  /** @var \Drupal\Core\Entity\ContentEntityForm $form_object */
+  $form_object = $form_state->getFormObject();
+  /** @var \Drupal\contact\MessageInterface $contact_message */
+  $contact_message = $form_object->getEntity();
+  /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+  $contact_form = ContactForm::load($contact_message->bundle());
+
+  // Display header as ecl paragraph.
+  $form['header']['#markup'] = '<p class="ecl-u-type-paragraph">' . $form['header']['#markup'] . '</p>';
+  // Logged in user name should display in its own line.
+  if ($form['name']['#type'] === 'item') {
+    $form['name']['#field_prefix'] = '<div class="ecl-u-mt-xs">';
+    $form['name']['#field_suffix'] = '</div>';
+  }
+  // Logged in user mail should display in its own line.
+  if ($form['mail']['#type'] === 'item') {
+    $form['mail']['#field_prefix'] = '<div class="ecl-u-mt-xs">';
+    $form['mail']['#field_suffix'] = '</div>';
+  }
+  // Add ecl link classes to the privacy link.
+  $privacy_link = $contact_form->getThirdPartySetting('oe_contact_forms', 'privacy_policy', FALSE);
+  $privacy_title = t('I have read and agree with the <a class="ecl-u-ml-2xs ecl-link ecl-link--default" href="@link" target="_blank">data protection terms</a></label>', [
+    '@link' => $privacy_link,
+  ]);
+  $form['privacy_policy']['#title'] = $privacy_title;
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
+  if (!isset($variables['message_list']['status'])) {
+    return;
+  }
+
+  foreach ($variables['message_list']['status'] as $key => $value) {
+    // Target contact_messages.
+    if (!is_array($value) || !isset($value['#contact_message'])) {
+      continue;
+    }
+
+    /** @var \Drupal\contact\MessageInterface $contact_message */
+    $contact_message = $value['#contact_message'];
+    /** @var \Drupal\contact\Entity\ContactForm $contact_form */
+    $contact_form = ContactForm::load($contact_message->bundle());
+    $is_corporate_form = (boolean) $contact_form->getThirdPartySetting('oe_contact_forms', 'is_corporate_form', FALSE);
+
+    // We work only with corporate forms from here.
+    if (!$is_corporate_form) {
+      continue;
+    }
+
+    $optional_selected = $contact_form->getThirdPartySetting('oe_contact_forms', 'optional_fields', []);
+    $items = [];
+    $fields = [
+      'name',
+      'mail',
+      'subject',
+      'message',
+      'oe_topic',
+    ];
+
+    // Include the optional fields.
+    if (in_array('oe_country_residence', $optional_selected)) {
+      $fields[] = 'oe_country_residence';
+    }
+    if (in_array('oe_telephone', $optional_selected)) {
+      $fields[] = 'oe_telephone';
+    }
+
+    // Build the label body pairs for the field_list pattern.
+    foreach ($fields as $field_name) {
+      /** @var \Drupal\Core\Field\FieldItemList $field */
+      $field = $contact_message->get($field_name);
+      $display_settings = ['label' => 'hidden'];
+
+      if ($field_name == 'oe_country_residence') {
+        $display_settings = ['label' => 'hidden', 'settings' => ['link' => FALSE]];
+      }
+
+      $field_view = $field->view($display_settings);
+      $items[] = [
+        'label' => $field_view['#title'],
+        'body' => $field_view,
+      ];
+    }
+
+    $variables['message_list']['status'][$key] = [
+      '#type' => 'pattern',
+      '#id' => 'field_list',
+      '#variant' => 'horizontal',
+      '#fields' => [
+        'items' => $items,
+      ],
+    ];
+  }
+}

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -99,21 +99,22 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
     foreach ($fields as $field_name) {
       /** @var \Drupal\Core\Field\FieldItemList $field */
       $field = $contact_message->get($field_name);
-      $display_settings = ['label' => 'hidden'];
-
-      if ($field->getFieldDefinition()->getType() == 'skos_concept_entity_reference') {
-        $display_settings = ['label' => 'hidden', 'settings' => ['link' => FALSE]];
-      }
-
-      $field_view = $field->view($display_settings);
-
-      if (!isset($field_view['#title'])) {
+      if ($field->isEmpty() || !$field->access()){
         continue;
       }
 
+      $display_settings = ['label' => 'hidden'];
+      if ($field->getFieldDefinition()->getType() == 'skos_concept_entity_reference') {
+        $display_settings += [
+          'settings' => [
+            'link' => FALSE,
+          ],
+        ];
+      }
+
       $items[] = [
-        'label' => $field_view['#title'],
-        'body' => $field_view,
+        'label' => $field->getFieldDefinition()->getLabel(),
+        'body' => $field->view($display_settings),
       ];
     }
 

--- a/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
+++ b/modules/oe_theme_contact_forms/oe_theme_contact_forms.module
@@ -9,6 +9,7 @@ declare(strict_types = 1);
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\contact\Entity\ContactForm;
+use Drupal\contact\MessageInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter() for contact_message_form().
@@ -57,7 +58,11 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
 
   foreach ($variables['message_list']['status'] as $key => $value) {
     // Target contact_messages which are being rendered in the status message.
-    if (!is_array($value) || !isset($value['#contact_message'])) {
+    if (
+      !is_array($value) ||
+      !isset($value['#contact_message']) ||
+      !$value['#contact_message'] instanceof MessageInterface
+    ) {
       continue;
     }
 
@@ -74,13 +79,21 @@ function oe_theme_contact_forms_preprocess_status_messages(&$variables) {
 
     $optional_fields = $contact_form->getThirdPartySetting('oe_contact_forms', 'optional_fields', []);
     $items = [];
-    $fields = array_merge([
+    $fields = [
       'name',
       'mail',
       'subject',
       'message',
       'oe_topic',
-    ], array_values($optional_fields));
+    ];
+
+    if (in_array('oe_country_residence', $optional_fields)) {
+      $fields[] = 'oe_country_residence';
+    }
+
+    if (in_array('oe_telephone', $optional_fields)) {
+      $fields[] = 'oe_telephone';
+    }
 
     // Build the label body pairs for the field_list pattern.
     foreach ($fields as $field_name) {

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1134,7 +1134,7 @@ function oe_theme_preprocess_input__search(array &$variables): void {
  * Implements hook_preprocess_input().
  */
 function oe_theme_preprocess_input(array &$variables) {
-  if ($variables['element']['#type'] == 'tel') {
+  if ($variables['element']['#type'] === 'tel') {
     $variables['attributes']['class'][] = 'ecl-text-input';
     $variables['attributes']['size'] = 60;
   }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -496,16 +496,6 @@ function oe_theme_preprocess_form_element(array &$variables): void {
   if (isset($ecl_type_mappings[$variables['element']['#type']])) {
     $variables['ecl_type'] = $ecl_type_mappings[$variables['element']['#type']];
   }
-  // Ensure we have class attribute.
-  $variables = array_merge_recursive($variables, [
-    'attributes' => [
-      'class' => [],
-    ],
-  ]);
-  // Add top and bottom margin.
-  if (!in_array('ecl-u-mt-l', $variables['attributes']['class'])) {
-    $variables['attributes']['class'][] = 'ecl-u-mv-m';
-  }
 }
 
 /**
@@ -1128,16 +1118,6 @@ function oe_theme_theme_suggestions_form_alter(array &$suggestions, array $varia
  */
 function oe_theme_preprocess_input__search(array &$variables): void {
   $variables['input_array'] = _oe_theme_preprocess_search_input_text($variables['element']);
-}
-
-/**
- * Implements hook_preprocess_input().
- */
-function oe_theme_preprocess_input(array &$variables) {
-  if ($variables['element']['#type'] === 'tel') {
-    $variables['attributes']['class'][] = 'ecl-text-input';
-    $variables['attributes']['size'] = 60;
-  }
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -496,6 +496,16 @@ function oe_theme_preprocess_form_element(array &$variables): void {
   if (isset($ecl_type_mappings[$variables['element']['#type']])) {
     $variables['ecl_type'] = $ecl_type_mappings[$variables['element']['#type']];
   }
+  // Ensure we have class attribute.
+  $variables = array_merge_recursive($variables, [
+    'attributes' => [
+      'class' => [],
+    ],
+  ]);
+  // Add top and bottom margin.
+  if (!in_array('ecl-u-mt-l', $variables['attributes']['class'])) {
+    $variables['attributes']['class'][] = 'ecl-u-mv-m';
+  }
 }
 
 /**
@@ -1118,6 +1128,16 @@ function oe_theme_theme_suggestions_form_alter(array &$suggestions, array $varia
  */
 function oe_theme_preprocess_input__search(array &$variables): void {
   $variables['input_array'] = _oe_theme_preprocess_search_input_text($variables['element']);
+}
+
+/**
+ * Implements hook_preprocess_input().
+ */
+function oe_theme_preprocess_input(array &$variables) {
+  if ($variables['element']['#type'] == 'tel') {
+    $variables['attributes']['class'][] = 'ecl-text-input';
+    $variables['attributes']['size'] = 60;
+  }
 }
 
 /**

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -23,6 +23,7 @@ drupal:
     - "./vendor/bin/drush en oe_theme_content_policy -y"
     - "./vendor/bin/drush en oe_theme_content_publication -y"
     - "./vendor/bin/drush en oe_theme_content_event -y"
+    - "./vendor/bin/drush en oe_theme_contact_forms -y"
     - "./vendor/bin/drush en field_ui -y"
     - "./vendor/bin/drush en config_devel -y"
     - "./vendor/bin/drush en toolbar -y"

--- a/templates/compositions/ec-component-checkbox/checkbox.html.twig
+++ b/templates/compositions/ec-component-checkbox/checkbox.html.twig
@@ -39,6 +39,7 @@
 {% set _css_class = 'ecl-checkbox' %}
 {% set _extra_attributes = '' %}
 {% set _extra_input_attributes = '' %}
+{% set _required = false %}
 
 {# Internal logic - Process properties #}
 
@@ -64,6 +65,9 @@
 {% if extra_input_attributes is defined and extra_input_attributes is not empty and extra_input_attributes is iterable %}
   {% for attr in extra_input_attributes %}
     {% set _extra_input_attributes = _extra_input_attributes ~ ' ' ~ attr.name ~ '="' ~ attr.value ~ '"' %}
+    {% if attr.name == 'required' %}
+      {% set _required = true %}
+    {% endif %}
   {% endfor %}
 {% endif %}
 
@@ -82,7 +86,7 @@
     {{ _extra_input_attributes|raw }}
   />
 
-  <label for="{{ _id }}" class="ecl-checkbox__label">
+  <label for="{{ _id }}" class="ecl-checkbox__label {{ _required ? "form-required" }}">
     <span class="ecl-checkbox__box">
       {% include '@ecl-twig/icon' with {
         icon: {

--- a/templates/compositions/ec-component-checkbox/checkbox.html.twig
+++ b/templates/compositions/ec-component-checkbox/checkbox.html.twig
@@ -86,7 +86,7 @@
     {{ _extra_input_attributes|raw }}
   />
 
-  <label for="{{ _id }}" class="ecl-checkbox__label {{ _required ? "form-required" }}">
+  <label for="{{ _id }}" class="ecl-checkbox__label{{ _required ? " form-required" }}">
     <span class="ecl-checkbox__box">
       {% include '@ecl-twig/icon' with {
         icon: {

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -18,6 +18,7 @@
     title_display not in ['after', 'before'] ? 'form-no-label',
     disabled == 'disabled' ? 'form-disabled',
     errors ? 'form-item--error',
+    'ecl-u-mv-m',
   ]
 %}
 {%

--- a/templates/form/input--tel.html.twig
+++ b/templates/form/input--tel.html.twig
@@ -1,0 +1,15 @@
+{#
+/**
+ * @file
+ * Theme override for an 'input' #type form element.
+ *
+ * @see ./core/themes/stable/templates/form/input.html.twig
+ */
+#}
+{%
+  set classes = [
+  'ecl-text-input',
+  attributes.hasClass('error') ? 'ecl-text-input--invalid',
+]
+%}
+<input{{ attributes.addClass(classes).setAttribute('size', '60') }} />{{ children }}

--- a/tests/Kernel/ContactFormRenderTest.php
+++ b/tests/Kernel/ContactFormRenderTest.php
@@ -44,8 +44,7 @@ class ContactFormRenderTest extends ContactFormTestBase {
   public function testContactForm(): void {
     $contact_form = ContactForm::create(['id' => 'oe_contact_form']);
     $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
-    $header = 'this is a test header';
-    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', 'this is a test header');
     $privacy_url = 'http://example.net';
     $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_url);
     $optional_selected = ['oe_telephone' => 'oe_telephone'];

--- a/tests/Kernel/ContactFormRenderTest.php
+++ b/tests/Kernel/ContactFormRenderTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\Kernel;
+
+use Drupal\contact\Entity\ContactForm;
+use Drupal\Tests\oe_contact_forms\Kernel\ContactFormTestBase;
+use Symfony\Component\DomCrawler\Crawler;
+
+/**
+ * Tests that our contact forms renders with ecl markup.
+ */
+class ContactFormRenderTest extends ContactFormTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'ui_patterns',
+    'ui_patterns_library',
+    'oe_theme_helper',
+    'breakpoint',
+    'responsive_image',
+    'image',
+    'oe_theme_contact_forms',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->installConfig(['system', 'image', 'responsive_image', 'contact']);
+    $this->container->get('theme_installer')->install(['oe_theme']);
+    $this->container->get('theme_handler')->setDefault('oe_theme');
+    $this->container->set('theme.registry', NULL);
+  }
+
+  /**
+   * Tests that corporate contact form is rendered with the correct ECL markup.
+   */
+  public function testContactForm(): void {
+    $contact_form = ContactForm::create(['id' => 'oe_contact_form']);
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'is_corporate_form', TRUE);
+    $header = 'this is a test header';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'header', $header);
+    $privacy_url = 'http://example.net';
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'privacy_policy', $privacy_url);
+    $optional_selected = ['oe_telephone' => 'oe_telephone'];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'optional_fields', $optional_selected);
+    $topics = [['topic_name' => 'Topic name', 'topic_email_address' => 'topic@emailaddress.com']];
+    $contact_form->setThirdPartySetting('oe_contact_forms', 'topics', $topics);
+    $contact_form->save();
+
+    /** @var \Drupal\contact\MessageInterface $contact_message */
+    $message = $this->container->get('entity_type.manager')->getStorage('contact_message')->create([
+      'contact_form' => $contact_form->id(),
+      'name' => 'sender_name',
+      'mail' => 'test@example.com',
+      'subject' => 'subject',
+      'message' => 'welcome_message',
+      'oe_telephone' => '0123456',
+      'oe_topic' => 'Topic name',
+    ]);
+
+    /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+    $entity_type_manager = $this->container->get('entity_type.manager');
+
+    $form = $this->container->get('entity.form_builder')->getForm($message, 'corporate_default');
+    $crawler = new Crawler($this->render($form));
+
+    $actual = $crawler->filter('p.ecl-u-type-paragraph');
+    $this->assertCount(1, $actual);
+    $actual = $crawler->filter('.ecl-u-ml-2xs.ecl-link.ecl-link--default');
+    $this->assertCount(1, $actual);
+    $actual = $crawler->filter('.ecl-u-mv-m');
+    $this->assertCount(7, $actual);
+    $telephone = $crawler->filter('.field--name-oe-telephone input');
+    $this->assertEqual(60, $telephone->attr('size'));
+    $this->assertContains('ecl-text-input', $telephone->attr('class'));
+
+    /** @var \Drupal\Core\Messenger\MessengerInterface $messenger */
+    $messenger = $this->container->get('messenger');
+
+    $full_view = $entity_type_manager->getViewBuilder('contact_message')->view($message, 'full');
+    $messenger->addMessage($full_view);
+    $messages = $messenger->messagesByType('status');
+    $html = $this->render($messages);
+    $crawler = new Crawler($html);
+
+    $actual = $crawler->filter('dl.ecl-description-list--horizontal');
+    $this->assertCount(1, $actual);
+    $actual = $crawler->filter('dt.ecl-description-list__term');
+    $this->assertCount(6, $actual);
+    $actual = $crawler->filter('dd.ecl-description-list__definition');
+    $this->assertCount(6, $actual);
+  }
+
+}


### PR DESCRIPTION
## OPENEUROPA-3282

### Description

Integrate oe_contact_forms for themeing.

### Change log

- Added: oe_theme_contact_forms companion module
- Changed:
  - add oe_contact_forms to composer.json
  - preprocess_form_element to add vertical spacing between elements
  - hook_preprocess_input to add ecl clases to tel input fields
  - runner.yml to enable the new module
  - checkbox composition to add required class if set


