### PR TITLE
OPENEUROPA-2626: Add top group

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.1",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "dev-master",
+        "openeuropa/oe_content": "dev-EPIC-Project",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "^1.4",

--- a/modules/oe_theme_content_project/README.md
+++ b/modules/oe_theme_content_project/README.md
@@ -1,0 +1,49 @@
+# OpenEuropa Content Project companion module
+
+This module is a theming companion module to the [OpenEuropa Content Project](https://github.com/openeuropa/oe_content/tree/EPIC-Project/modules/oe_content_project) module.
+It provides the logic needed to theme the Project content type.
+
+## Installation
+
+Make sure you have read the OpenEuropa Content Project module's [README.md](https://github.com/openeuropa/oe_content/blob/EPIC-Project/modules/oe_content_project/README.md)
+before enabling this module.
+
+After enabling this module make sure you assign the following permissions to the anonymous user role, so visitors can
+correctly access all project information.
+
+- `Organisation: View any published entity`
+
+## Required contrib modules
+
+This module requires the following contributed modules:
+
+* [Extra field](https://www.drupal.org/project/extra_field) (^1.1)
+* [Field group](https://www.drupal.org/project/field_group) (~3.0)
+
+## Shipped configuration
+
+The modules ships configuration date format which is made for presenting `Project duration`.
+
+List of shipped date formats:
+
+* Project period, e.g. `23.06.2020`
+
+## Overridden configuration
+
+Installing this module will override the default project content type view mode, shipped by the
+[OpenEuropa Content Project](https://github.com/openeuropa/oe_content/tree/EPIC-Project/modules/oe_content_project)
+module. This is necessary in order to guarantee that fields and formatter settings are displayed correctly.
+
+If you want to customize how the project looks like create the `full` view mode and take over.
+
+## Extra fields
+
+This module ships with a [extra field](https://www.drupal.org/project/extra_field) plugin definition which is
+used to display complex rendering business logic. All this logic is encapsulated in this extra field.
+
+You can reuse these extra fields in your own view modes.
+
+List of Extra field definitions:
+
+* [Percentage](modules/oe_theme_content_project/src/Plugin/ExtraField/Display/PercentageExtraField.php) provides a field that
+calculates the eu percentage of the project budget.

--- a/modules/oe_theme_content_project/config/install/core.date_format.project_period.yml
+++ b/modules/oe_theme_content_project/config/install/core.date_format.project_period.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: oe_project_date
+label: 'Project period'
+locked: false
+pattern: d.m.Y

--- a/modules/oe_theme_content_project/config/overrides/core.entity_view_display.node.oe_project.default.yml
+++ b/modules/oe_theme_content_project/config/overrides/core.entity_view_display.node.oe_project.default.yml
@@ -1,0 +1,199 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.oe_project.body
+    - field.field.node.oe_project.oe_author
+    - field.field.node.oe_project.oe_project_budget
+    - field.field.node.oe_project.oe_project_budget_eu
+    - field.field.node.oe_project.oe_project_calls
+    - field.field.node.oe_project.oe_project_dates
+    - field.field.node.oe_project.oe_project_departments
+    - field.field.node.oe_project.oe_project_result_files
+    - field.field.node.oe_project.oe_project_results
+    - field.field.node.oe_project.oe_project_website
+    - field.field.node.oe_project.oe_reference
+    - field.field.node.oe_project.oe_subject
+    - field.field.node.oe_project.oe_summary
+    - field.field.node.oe_project.oe_teaser
+    - node.type.oe_project
+  module:
+    - datetime_range
+    - entity_reference_revisions
+    - field_group
+    - link
+    - rdf_skos
+    - text
+    - user
+third_party_settings:
+  field_group:
+    group_top:
+      children:
+        - body
+        - group_details
+        - group_budget
+        - group_resources
+      parent_name: ''
+      weight: 0
+      format_type: html_element
+      region: content
+      format_settings:
+        id: ''
+        classes: ''
+        element: div
+        show_label: false
+        label_element: h3
+        label_element_classes: ''
+        attributes: ''
+        effect: none
+        speed: fast
+        direction: vertical
+      label: Top
+    group_details:
+      children:
+        - oe_reference
+        - oe_project_dates
+      parent_name: group_top
+      weight: 2
+      format_type: oe_theme_helper_field_list_pattern
+      region: content
+      format_settings:
+        variant: horizontal
+        direction: vertical
+        classes: ''
+        id: ''
+      label: Details
+    group_budget:
+      children:
+        - oe_project_budget
+        - oe_project_budget_eu
+        - extra_field_oe_theme_content_project_percentage
+      parent_name: group_top
+      weight: 3
+      format_type: oe_theme_helper_field_list_pattern
+      region: content
+      format_settings:
+        variant: horizontal
+        direction: vertical
+        classes: ''
+        id: ''
+      label: Budget
+    group_resources:
+      children:
+        - oe_project_website
+        - oe_project_departments
+      parent_name: group_top
+      weight: 4
+      format_type: oe_theme_helper_field_list_pattern
+      region: content
+      format_settings:
+        variant: horizontal
+        direction: vertical
+        classes: ''
+        id: ''
+      label: Resources
+id: node.oe_project.default
+targetEntityType: node
+bundle: oe_project
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+  extra_field_oe_theme_content_project_percentage:
+    weight: 9
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  oe_project_budget:
+    type: number_decimal
+    weight: 7
+    region: content
+    label: above
+    settings:
+      thousand_separator: .
+      decimal_separator: .
+      scale: 0
+      prefix_suffix: true
+    third_party_settings: {  }
+  oe_project_budget_eu:
+    type: number_decimal
+    weight: 8
+    region: content
+    label: above
+    settings:
+      thousand_separator: .
+      decimal_separator: .
+      scale: 0
+      prefix_suffix: true
+    third_party_settings: {  }
+  oe_project_dates:
+    type: daterange_default
+    weight: 1
+    region: content
+    label: above
+    settings:
+      timezone_override: ''
+      format_type: oe_project_date
+      separator: '-'
+    third_party_settings: {  }
+  oe_project_departments:
+    type: skos_concept_entity_reference_label
+    weight: 6
+    region: content
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  oe_project_result_files:
+    weight: 5
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    type: entity_reference_revisions_entity_view
+    region: content
+  oe_project_results:
+    type: text_default
+    weight: 4
+    region: content
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+  oe_project_website:
+    type: link
+    weight: 5
+    region: content
+    label: above
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  oe_reference:
+    type: string
+    weight: 0
+    region: content
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  langcode: true
+  links: true
+  oe_author: true
+  oe_content_content_owner: true
+  oe_content_legacy_link: true
+  oe_content_navigation_title: true
+  oe_content_short_title: true
+  oe_project_calls: true
+  oe_subject: true
+  oe_summary: true
+  oe_teaser: true

--- a/modules/oe_theme_content_project/oe_theme_content_project.info.yml
+++ b/modules/oe_theme_content_project/oe_theme_content_project.info.yml
@@ -1,0 +1,10 @@
+name: OpenEuropa Theme Project Content
+type: module
+description: Companion module for the OE Content Project module
+package: OpenEuropa
+core: 8.x
+dependencies:
+  - extra_field:extra_field
+  - oe_content:oe_content_project
+  - oe_theme:oe_theme_helper
+  - field_group:field_group

--- a/modules/oe_theme_content_project/oe_theme_content_project.install
+++ b/modules/oe_theme_content_project/oe_theme_content_project.install
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @file
+ * Install function for the module.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Entity\Entity\EntityViewDisplay;
+
+/**
+ * Implements hook_install().
+ */
+function oe_theme_content_project_install() {
+  // If we are installing from config, we bail out.
+  if (\Drupal::isConfigSyncing() === TRUE) {
+    return;
+  }
+
+  // Override entity view display.
+  $storage = new FileStorage(drupal_get_path('module', 'oe_theme_content_project') . '/config/overrides');
+  $display = 'core.entity_view_display.node.oe_project.default';
+  $values = $storage->read($display);
+  $config = EntityViewDisplay::load($values['id']);
+
+  foreach ($values as $key => $value) {
+    $config->set($key, $value);
+  }
+  $config->save();
+}

--- a/modules/oe_theme_content_project/oe_theme_content_project.module
+++ b/modules/oe_theme_content_project/oe_theme_content_project.module
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ * Module file used for theming the Project content type.
+ */
+
+declare(strict_types = 1);
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+
+/**
+ * Implements hook_ENTITY_TYPE_view_alter().
+ */
+function oe_theme_content_project_node_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  // Run only on project content type.
+  if ($entity->bundle() !== 'oe_project') {
+    return;
+  }
+
+  // Field labels are different in frontend and backend.
+  // Here we override them, per view mode.
+  if ($build['#view_mode'] === 'full') {
+    $label_overrides = [
+      'oe_project_dates' => t('Project duration'),
+      'oe_project_website' => t('Project website'),
+    ];
+    // If there is only a start date, set "Start date" as label.
+    $dates = $entity->get('oe_project_dates')->getValue();
+    if (!$dates[0]['end_value'] || $dates[0]['value'] === $dates[0]['end_value']) {
+      $label_overrides['oe_project_dates'] = t('Start date');
+    }
+
+    foreach ($label_overrides as $name => $label_override) {
+      if (!$entity->get($name)->isEmpty() && isset($build[$name]['#title'])) {
+        $build[$name]['#title'] = $label_override;
+      }
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_field().
+ */
+function oe_theme_content_project_preprocess_field(&$variables) {
+  // Add ecl link classes to oe_project link fields.
+  if (in_array($variables['element']['#field_name'], ['oe_project_departments', 'oe_project_website'])) {
+    foreach ($variables['items'] as $key => $value) {
+      $variables['items'][$key]['content']['#options']['attributes']['class'][] = "ecl-link";
+      $variables['items'][$key]['content']['#options']['attributes']['class'][] = "ecl-link--standalone";
+    }
+  }
+}

--- a/modules/oe_theme_content_project/src/Plugin/ExtraField/Display/PercentageExtraField.php
+++ b/modules/oe_theme_content_project/src/Plugin/ExtraField/Display/PercentageExtraField.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_content_project\Plugin\ExtraField\Display;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Cache\CacheableMetadata;
+
+/**
+ * Extra field displaying eu budget percentage on projects.
+ *
+ * @ExtraFieldDisplay(
+ *   id = "oe_theme_content_project_percentage",
+ *   label = @Translation("Percentage"),
+ *   bundles = {
+ *     "node.oe_project",
+ *   },
+ *   visible = true
+ * )
+ */
+class PercentageExtraField extends ProjectExtraFieldBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getLabel() {
+    // Add space as label so the value aligns with the other fields.
+    return ' ';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function viewElements(ContentEntityInterface $entity) {
+    // Compute budget percentage field value.
+    $budget = $entity->get('oe_project_budget')->value;
+    $budget_eu = $entity->get('oe_project_budget_eu')->value;
+    $percentage = $this->getPercentage((float) $budget, (float) $budget_eu);
+    $build = [
+      '#plain_text' => $this->t("@percentage% of the overall budget", ["@percentage" => $percentage]),
+    ];
+    $cache = new CacheableMetadata();
+    $cache->addCacheableDependency($entity);
+    $cache->applyTo($build);
+
+    return $build;
+  }
+
+  /**
+   * Gets the percentage of total, without decimals.
+   *
+   * If input values are not greater that 0, returns 0.
+   *
+   * @param float $total
+   *   The total value.
+   * @param float $part
+   *   The percentage value.
+   *
+   * @return float
+   *   Percentage value.
+   */
+  private function getPercentage(float $total, float $part): float {
+    $percentage = 0;
+
+    if ($total > 0 && $part > 0) {
+      $percentage = round(100 * $part / $total, 0);
+    }
+
+    return $percentage;
+  }
+
+}

--- a/modules/oe_theme_content_project/src/Plugin/ExtraField/Display/ProjectExtraFieldBase.php
+++ b/modules/oe_theme_content_project/src/Plugin/ExtraField/Display/ProjectExtraFieldBase.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\oe_theme_content_project\Plugin\ExtraField\Display;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\extra_field\Plugin\ExtraFieldDisplayFormattedBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Base class for Project extra fields.
+ */
+abstract class ProjectExtraFieldBase extends ExtraFieldDisplayFormattedBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityViewBuilderInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * ProjectExtraFieldBase constructor.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
+  }
+
+}

--- a/modules/oe_theme_content_project/templates/field--node--oe-project-results--oe-project--full.html.twig
+++ b/modules/oe_theme_content_project/templates/field--node--oe-project-results--oe-project--full.html.twig
@@ -1,0 +1,70 @@
+{#
+/**
+ * @file
+ * Theme override for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{%
+  set title_classes = [
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+%}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes }}>
+      {% for item in items %}
+        <div{{ item.attributes }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div class="ecl-editor">
+    <h2{{ title_attributes.addClass(title_classes) }}>{{ label }}</h2>
+    {% if multiple %}
+      <div>
+    {% endif %}
+    {% for item in items %}
+      <div{{ item.attributes }}>{{ item.content }}</div>
+    {% endfor %}
+    {% if multiple %}
+      </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/modules/oe_theme_content_project/templates/pattern-field-list--variant-horizontal-oe-project.html.twig
+++ b/modules/oe_theme_content_project/templates/pattern-field-list--variant-horizontal-oe-project.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Field list horizontal oe_project variant.
+ */
+#}
+<div class="ecl-u-bg-blue-5 ecl-u-border-all ecl-u-border-width-2 ecl-u-border-color-blue-25 ecl-u-mb-s ecl-u-pv-s ecl-u-ph-xs">
+  {% set _items = [] %}
+  {% for _item in items %}
+    {% set _items = _items|merge([{
+      term: _item.label,
+      definition: _item.body|render
+    }]) %}
+  {% endfor %}
+
+  {% include '@ecl-twig/description-list' with {
+    'variant': variant,
+    'items': _items,
+  } %}
+</div>

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -25,6 +25,7 @@ use Drupal\oe_theme\ValueObject\DateValueObject;
 use Drupal\oe_theme\ValueObject\GalleryItemValueObject;
 use Drupal\oe_theme\ValueObject\ImageValueObject;
 use Drupal\oe_theme_helper\EuropeanUnionLanguages;
+use Drupal\ui_patterns\Element\PatternContext;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -1501,6 +1502,25 @@ function oe_theme_theme_suggestions_page_alter(array &$suggestions, array $varia
   if ($route->getRouteName() === 'entity.node.preview') {
     $suggestions[] = 'page__node__' . $route->getParameter('node_preview')->bundle();
     $suggestions[] = 'page__node__preview__' . $route->getParameter('node_preview')->bundle();
+  }
+}
+
+/**
+ * Implements hook_ui_patterns_suggestions_alter().
+ */
+function oe_theme_ui_patterns_suggestions_alter(array &$suggestions, array $variables, PatternContext $context) {
+  $hook = $variables['theme_hook_original'];
+  $variant = $variables['variant'];
+  // Add suggestions for pattern_field_list horizontal variant.
+  if ($hook === 'pattern_field_list' && $variant === 'horizontal') {
+    foreach ($variables['items'] as $item) {
+      $bundle = isset($item['body']['#bundle']) ? '_' . $item['body']['#bundle'] : '';
+      $suggestion = $hook . '__variant_' . $variant . $bundle;
+      // Check for duplicates.
+      if (!in_array($suggestion, $suggestions)) {
+        $suggestions[] = $suggestion;
+      }
+    }
   }
 }
 

--- a/runner.yml.dist
+++ b/runner.yml.dist
@@ -23,6 +23,7 @@ drupal:
     - "./vendor/bin/drush en oe_theme_content_policy -y"
     - "./vendor/bin/drush en oe_theme_content_publication -y"
     - "./vendor/bin/drush en oe_theme_content_event -y"
+    - "./vendor/bin/drush en oe_theme_content_project -y"
     - "./vendor/bin/drush en field_ui -y"
     - "./vendor/bin/drush en config_devel -y"
     - "./vendor/bin/drush en toolbar -y"

--- a/sass/components/_project_right_box.scss
+++ b/sass/components/_project_right_box.scss
@@ -1,0 +1,9 @@
+// Remove margin left to avoid overflow.
+#project-details .ecl-description-list__definition{
+  margin-left: 0;
+}
+@include ecl-media-breakpoint-up('lg') {
+  .ecl-description-list--horizontal .ecl-description-list__definition {
+    width: 312px;
+  }
+}

--- a/sass/style-ec.scss
+++ b/sass/style-ec.scss
@@ -5,3 +5,4 @@
 @import "./components/toolbar";
 @import "./components/banner";
 @import "./components/wysiwyg";
+@import "./components/project_right_box";

--- a/sass/style-eu.scss
+++ b/sass/style-eu.scss
@@ -9,3 +9,4 @@
 @import "./components/toolbar";
 @import "./components/banner";
 @import "./components/wysiwyg";
+@import "./components/project_right_box";

--- a/templates/content/field-group-html-element--node--oe-project--group-top.html.twig
+++ b/templates/content/field-group-html-element--node--oe-project--group-top.html.twig
@@ -1,0 +1,27 @@
+{#
+/**
+ * @file
+ * Theme override for a fieldgroup html element.
+ *
+ * Available variables:
+ * - title: Title of the group.
+ * - title_element: Element to wrap the title.
+ * - element: The children of the group.
+ * - wrapper_element: The html element to use
+ * - attributes: A list of HTML attributes for the group wrapper.
+ *
+ * @see template_preprocess_field_group_html_element()
+ *
+ * @ingroup themeable
+ */
+#}
+<div id="project-details" class="ecl-row">
+  <div class="ecl-col-12 ecl-col-md-6">
+    {{ element.body }}
+  </div>
+  <div class="ecl-col-12 ecl-col-md-6 ecl-u-mt-l ecl-u-mt-md-none">
+    {{ element.group_details }}
+    {{ element.group_budget }}
+    {{ element.group_resources }}
+  </div>
+</div>


### PR DESCRIPTION
## OPENEUROPA-2626

### Description

Add top group, devided into two columns, first column containing body and results, the second column containing Details, Budget, Resources sub-groups.

### Change log

- Added:
  - oe_theme_content_project companion module
  - suggestions for pattern_field_list horizontal variant


