### PR TITLE
OPENEUROPA-3331: Fix document rendering.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1206,12 +1206,25 @@ function oe_theme_preprocess_media__document__default(&$variables) {
   if ($variables['media']->get('oe_media_file')->isEmpty()) {
     return;
   }
-
+  // Generate the file information for the current language.
   /** @var \Drupal\media\Entity\Media $media */
   $media = $variables['media'];
   $file_object = $media->get('oe_media_file')->first()->entity;
   $variables['file'] = FileValueObject::fromFileEntity($file_object)
-    ->setTitle($media->getName());
+    ->setTitle($media->getName())
+    ->setLanguageCode($media->language()->getId());
+  // Generate the file information for all available translations.
+  foreach ($media->getTranslationLanguages() as $langcode => $language) {
+    // We don't want to include the information of the current language again.
+    if ($media->language()->getId() === $langcode) {
+      continue;
+    }
+    $translation = $media->getTranslation($langcode);
+    $file_object = $translation->get('oe_media_file')->first()->entity;
+    $variables['translations'][] = FileValueObject::fromFileEntity($file_object)
+      ->setTitle($translation->getName())
+      ->setLanguageCode($translation->language()->getId());
+  }
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\Template\Attribute;
 use Drupal\Core\Url;
+use Drupal\file\FileInterface;
 use Drupal\media\MediaInterface;
 use Drupal\media\Plugin\media\Source\Image;
 use Drupal\media\Plugin\media\Source\OEmbed;
@@ -1221,9 +1222,11 @@ function oe_theme_preprocess_media__document__default(&$variables) {
     }
     $translation = $media->getTranslation($langcode);
     $file_object = $translation->get('oe_media_file')->first()->entity;
-    $variables['translations'][] = FileValueObject::fromFileEntity($file_object)
-      ->setTitle($translation->getName())
-      ->setLanguageCode($translation->language()->getId());
+    if ($file_object instanceof FileInterface) {
+      $variables['translations'][] = FileValueObject::fromFileEntity($file_object)
+        ->setTitle($translation->getName())
+        ->setLanguageCode($translation->language()->getId());
+    }
   }
 }
 

--- a/templates/content/media--document--default.html.twig
+++ b/templates/content/media--document--default.html.twig
@@ -6,7 +6,8 @@
  * @see ./core/themes/stable/templates/content/media.html.twig
  */
 #}
-{{ pattern('file', {
+{{ pattern('file_translation', {
   'button_label': 'Download'|t,
   'file': file|default([]),
+  'translations': translations|default([]),
 }) }}

--- a/templates/patterns/file_translation/file_translation.ui_patterns.yml
+++ b/templates/patterns/file_translation/file_translation.ui_patterns.yml
@@ -38,3 +38,8 @@ file_translation:
           size: "170000"
           name: "document.pdf"
           language_code: "hu"
+    more_info:
+      type: "text"
+      label: "More information"
+      description: "Informative text about the available translations."
+      preview: "Looking for another language which is not on the list? Find out why."

--- a/templates/patterns/file_translation/pattern-file-translation.html.twig
+++ b/templates/patterns/file_translation/pattern-file-translation.html.twig
@@ -54,7 +54,7 @@
         'transform': 'rotate-180',
       },
     },
-    'description': 'Looking for another language which is not on the list? Find out why.'|t,
+    'description': more_info|default(''),
     'items': _translations,
   }
 } only %}

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -4,12 +4,14 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_theme\Kernel;
 
+use Drupal\Core\Language\LanguageManager;
+use Drupal\oe_theme_helper\EuropeanUnionLanguages;
 use Symfony\Component\DomCrawler\Crawler;
 
 /**
  * Tests that our media types render with correct markup.
  */
-class MediaRenderTest extends AbstractKernelTestBase {
+class MediaRenderTest extends MultilingualAbstractKernelTestBase {
 
   /**
    * The media storage.
@@ -59,44 +61,101 @@ class MediaRenderTest extends AbstractKernelTestBase {
    * Tests that the Document media type is rendered with the correct ECL markup.
    */
   public function testDocumentMedia(): void {
-    $file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test.pdf');
-    $file->setPermanent();
-    $file->save();
+    // Make image media translatable.
+    $setting = $this->container->get('entity_type.manager')->getStorage('language_content_settings')->create([
+      'langcode' => 'en',
+      'statur' => TRUE,
+      'id' => 'media.document',
+      'target_entity_type_id' => 'media',
+      'target_bundle' => 'document',
+      'default_langcode' => 'site_default',
+      'language_alterable' => 'true',
+    ]);
+    $setting->setThirdPartySetting('content_translation', 'enabled', TRUE);
+    $setting->save();
 
+    $english_file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test_en.pdf');
+    $english_file->setPermanent();
+    $english_file->save();
+
+    $spanish_file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test_es.pdf');
+    $spanish_file->setPermanent();
+    $spanish_file->save();
+
+    /** @var \Drupal\media\MediaInterface $media */
     $media = $this->mediaStorage->create([
       'bundle' => 'document',
-      'name' => 'test document',
+      'name' => 'test document EN',
       'oe_media_file' => [
-        'target_id' => $file->id(),
+        'target_id' => $english_file->id(),
       ],
     ]);
 
     $media->save();
 
+    $media_spanish = $media->addTranslation('es', [
+      'name' => 'test document ES',
+      'oe_media_file' => [
+        'target_id' => $spanish_file->id(),
+      ],
+    ]);
+    $media_spanish->save();
+
+    $translation_languages = $media->getTranslationLanguages();
     foreach (['default', 'oe_theme_main_content'] as $view_mode) {
-      $build = $this->mediaViewBuilder->view($media, $view_mode);
-      $crawler = new Crawler($this->renderRoot($build));
+      foreach ($translation_languages as $document_langcode => $document_language) {
+        $build = $this->mediaViewBuilder->view($media, $view_mode, $document_langcode);
+        $crawler = new Crawler($this->renderRoot($build));
 
-      // File wrapper.
-      $file_wrapper = $crawler->filter('.ecl-file');
-      $this->assertCount(1, $file_wrapper);
+        // Check the rendering of the current language document.
+        // File wrapper.
+        $file_wrapper = $crawler->filter('.ecl-file');
+        $this->assertCount(1, $file_wrapper);
 
-      // File row.
-      $file_row = $crawler->filter('.ecl-file .ecl-file__container');
-      $this->assertCount(1, $file_row);
+        // File row.
+        $file_row = $crawler->filter('.ecl-file .ecl-file__container');
+        $this->assertCount(1, $file_row);
 
-      $file_title = $file_row->filter('.ecl-file__title');
-      $this->assertContains('test document', $file_title->text());
+        $file_title = $file_row->filter('.ecl-file__title');
+        $this->assertContains('test document', $file_title->text());
 
-      $file_info_language = $file_row->filter('.ecl-file__info div.ecl-file__language');
-      $this->assertContains('English', $file_info_language->text());
+        $file_info_language = $file_row->filter('.ecl-file__info div.ecl-file__language');
+        $this->assertContains($document_language->getName(), $file_info_language->text());
 
-      $file_info_properties = $file_row->filter('.ecl-file__info div.ecl-file__meta');
-      $this->assertContains('KB - PDF)', $file_info_properties->text());
+        $file_info_properties = $file_row->filter('.ecl-file__info div.ecl-file__meta');
+        $this->assertContains('KB - PDF)', $file_info_properties->text());
 
-      $file_download_link = $file_row->filter('.ecl-file__download');
-      $this->assertContains('/test.pdf', $file_download_link->attr('href'));
-      $this->assertContains('Download', $file_download_link->text());
+        $file_download_link = $file_row->filter('.ecl-file__download');
+        $this->assertContains('/test_' . $document_langcode . '.pdf', $file_download_link->attr('href'));
+        $this->assertContains('Download', $file_download_link->text());
+
+        // Check the rendering of the available translations.
+        // File translation list.
+        $translation_list = $crawler->filter('.ecl-file__translation-list');
+        $this->assertCount(1, $translation_list);
+
+        // Check the translation list description.
+        $translation_list_description = $translation_list->filter('.ecl-file__translation-item.ecl-file__translation-description');
+        $this->assertContains('Looking for another language which is not on the list? Find out why.', $translation_list_description->text());
+
+        // Get the available translation language.
+        $translation_language = array_filter($translation_languages, function ($langcode) use ($document_langcode) {
+          return $document_langcode != $langcode;
+        }, ARRAY_FILTER_USE_KEY);
+        /** @var \Drupal\Core\Language\Language $translation_language */
+        $translation_language = reset($translation_language);
+
+        $language_names = $predefined = EuropeanUnionLanguages::getLanguageList() + LanguageManager::getStandardLanguageList();
+        $translation_file_info_language = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-title');
+        $this->assertContains($language_names[$translation_language->getId()][1], $translation_file_info_language->text());
+
+        $translation_file_info_properties = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-meta');
+        $this->assertContains('KB - PDF)', $translation_file_info_properties->text());
+
+        $translation_file_download_link = $translation_list->filter('.ecl-file__translation-download');
+        $this->assertContains('/test_' . $translation_language->getId() . '.pdf', $translation_file_download_link->attr('href'));
+        $this->assertContains('Download', $file_download_link->text());
+      }
     }
   }
 

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -65,12 +65,12 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     // Make image media translatable.
     $setting = $this->container->get('entity_type.manager')->getStorage('language_content_settings')->create([
       'langcode' => 'en',
-      'statur' => TRUE,
+      'status' => TRUE,
       'id' => 'media.document',
       'target_entity_type_id' => 'media',
       'target_bundle' => 'document',
       'default_langcode' => 'site_default',
-      'language_alterable' => 'true',
+      'language_alterable' => TRUE,
     ]);
     $setting->setThirdPartySetting('content_translation', 'enabled', TRUE);
     $setting->save();
@@ -121,8 +121,8 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     ]);
     $media_spanish->save();
 
-    // Assert that the media is rendered properly with translations in
-    // all available languages.
+    // Assert that the media and its translations are rendered properly
+    // in all translated languages.
     $translation_languages = $media->getTranslationLanguages();
     foreach (['default', 'oe_theme_main_content'] as $view_mode) {
       foreach ($translation_languages as $document_langcode => $document_language) {
@@ -132,7 +132,6 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
         // Check the rendering of the current language document.
         $this->assertMainDocumentRendering($crawler, $document_language);
         // Check the rendering of the available translations.
-        // File translation list.
         $translation_list = $crawler->filter('.ecl-file__translation-list');
         $this->assertCount(1, $translation_list);
 
@@ -148,11 +147,11 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
         $translation_language = reset($translation_language);
 
         $language_names = $predefined = EuropeanUnionLanguages::getLanguageList() + LanguageManager::getStandardLanguageList();
-        $translation_file_info_language = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-title');
-        $this->assertContains($language_names[$translation_language->getId()][1], $translation_file_info_language->text());
+        $file_translation_info_language = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-title');
+        $this->assertContains($language_names[$translation_language->getId()][1], $file_translation_info_language->text());
 
-        $translation_file_info_properties = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-meta');
-        $this->assertContains('KB - PDF)', $translation_file_info_properties->text());
+        $file_translation_info_properties = $translation_list->filter('.ecl-file__translation-item .ecl-file__translation-info div.ecl-file__translation-meta');
+        $this->assertContains('KB - PDF)', $file_translation_info_properties->text());
 
         $translation_file_download_link = $translation_list->filter('.ecl-file__translation-download');
         $this->assertContains('/test_' . $translation_language->getId() . '.pdf', $translation_file_download_link->attr('href'));

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -91,7 +91,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     // View modes to test.
     $view_modes = ['default', 'oe_theme_main_content'];
 
-    // Assert tha the media is rendered properly without translations.
+    // Assert that the media is rendered properly without translations.
     foreach ($view_modes as $view_mode) {
       $build = $this->mediaViewBuilder->view($media, $view_mode);
       $crawler = new Crawler($this->renderRoot($build));

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -63,30 +63,18 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
    */
   public function testDocumentMedia(): void {
     // Make image media translatable.
-    $setting = $this->container->get('entity_type.manager')->getStorage('language_content_settings')->create([
-      'langcode' => 'en',
-      'status' => TRUE,
-      'id' => 'media.document',
-      'target_entity_type_id' => 'media',
-      'target_bundle' => 'document',
-      'default_langcode' => 'site_default',
-      'language_alterable' => TRUE,
-    ]);
-    $setting->setThirdPartySetting('content_translation', 'enabled', TRUE);
-    $setting->save();
+    $this->container->get('content_translation.manager')->setEnabled('media', 'document', TRUE);
+    $this->container->get('router.builder')->rebuild();
 
     // Create english file.
     $english_file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test_en.pdf');
     $english_file->setPermanent();
     $english_file->save();
 
-    // Create spanish file.
+    // Create Spanish file.
     $spanish_file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test_es.pdf');
     $spanish_file->setPermanent();
     $spanish_file->save();
-
-    // View modes to test.
-    $view_modes = ['default', 'oe_theme_main_content'];
 
     // Create a document media.
     /** @var \Drupal\media\MediaInterface $media */
@@ -99,6 +87,9 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     ]);
 
     $media->save();
+
+    // View modes to test.
+    $view_modes = ['default', 'oe_theme_main_content'];
 
     // Assert tha the media is rendered properly without translations.
     foreach ($view_modes as $view_mode) {
@@ -124,7 +115,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     // Assert that the media and its translations are rendered properly
     // in all translated languages.
     $translation_languages = $media->getTranslationLanguages();
-    foreach (['default', 'oe_theme_main_content'] as $view_mode) {
+    foreach ($view_modes as $view_mode) {
       foreach ($translation_languages as $document_langcode => $document_language) {
         $build = $this->mediaViewBuilder->view($media, $view_mode, $document_langcode);
         $crawler = new Crawler($this->renderRoot($build));
@@ -161,7 +152,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
   }
 
   /**
-   * Helper test to assert the rendering of the main document.
+   * Assert the rendering of the main document.
    *
    * @param \Symfony\Component\DomCrawler\Crawler $crawler
    *   The rendered html to check.

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -66,7 +66,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
     $this->container->get('content_translation.manager')->setEnabled('media', 'document', TRUE);
     $this->container->get('router.builder')->rebuild();
 
-    // Create english file.
+    // Create English file.
     $english_file = file_save_data(file_get_contents(drupal_get_path('module', 'oe_media') . '/tests/fixtures/sample.pdf'), 'public://test_en.pdf');
     $english_file->setPermanent();
     $english_file->save();
@@ -103,7 +103,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
       $this->assertCount(0, $translation_list);
     }
 
-    // Translate the media to spanish.
+    // Translate the media to Spanish.
     $media_spanish = $media->addTranslation('es', [
       'name' => 'test document ES',
       'oe_media_file' => [

--- a/tests/Kernel/MediaRenderTest.php
+++ b/tests/Kernel/MediaRenderTest.php
@@ -137,7 +137,7 @@ class MediaRenderTest extends MultilingualAbstractKernelTestBase {
 
         // Check the translation list description.
         $translation_list_description = $translation_list->filter('.ecl-file__translation-item.ecl-file__translation-description');
-        $this->assertContains('Looking for another language which is not on the list? Find out why.', $translation_list_description->text());
+        $this->assertEmpty($translation_list_description->text());
 
         // Get the available translation language.
         $translation_language = array_filter($translation_languages, function ($langcode) use ($document_langcode) {

--- a/tests/Kernel/MultilingualAbstractKernelTestBase.php
+++ b/tests/Kernel/MultilingualAbstractKernelTestBase.php
@@ -4,12 +4,10 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_theme\Kernel;
 
-use Drupal\KernelTests\KernelTestBase;
-
 /**
  * Base class for multilingual tests.
  */
-abstract class MultilingualAbstractKernelTestBase extends KernelTestBase {
+abstract class MultilingualAbstractKernelTestBase extends AbstractKernelTestBase {
 
   /**
    * Modules to enable.
@@ -38,8 +36,6 @@ abstract class MultilingualAbstractKernelTestBase extends KernelTestBase {
   protected function setUp() {
     parent::setUp();
 
-    $this->installEntitySchema('user');
-    $this->installSchema('system', 'sequences');
     $this->installSchema('locale', [
       'locales_location',
       'locales_source',
@@ -55,25 +51,12 @@ abstract class MultilingualAbstractKernelTestBase extends KernelTestBase {
       'responsive_image',
     ]);
 
-    $this->container->get('theme_installer')->install(['oe_theme']);
-    $this->container->get('theme_handler')->setDefault('oe_theme');
-    $this->container->set('theme.registry', NULL);
-
     $this->container->get('module_handler')->loadInclude('oe_multilingual', 'install');
     oe_multilingual_install();
 
     // Rebuild the container in order to make sure tests pass.
     // @todo: fix test setup so that we can get rid of this line.
     $this->container->get('kernel')->rebuildContainer();
-
-    // Call the install hook of the User module which creates the Anonymous user
-    // and User 1. This is needed because the Anonymous user is loaded to
-    // provide the current User context which is needed in places like route
-    // enhancers.
-    // @see CurrentUserContext::getRuntimeContexts().
-    // @see EntityConverter::convert().
-    module_load_include('install', 'user');
-    user_install();
   }
 
 }

--- a/tests/Kernel/fixtures/rendering.yml
+++ b/tests/Kernel/fixtures/rendering.yml
@@ -476,6 +476,7 @@
           size: "170000"
           name: "document.pdf"
           language_code: "hu"
+      more_info: "Custom information snippet."
   assertions:
     count:
       'svg.ecl-file__icon': 1
@@ -497,6 +498,7 @@
       '.ecl-file__translation-item:nth-child(2) div.ecl-file__translation-meta': "(156.25 KB - PDF)"
       '.ecl-file__translation-item:nth-child(3) div.ecl-file__translation-title': "magyar"
       '.ecl-file__translation-item:nth-child(3) div.ecl-file__translation-meta': "(166.02 KB - PDF)"
+      '.ecl-file__translation-description': "Custom information snippet."
 - array:
     '#type': pattern
     '#id': file_image


### PR DESCRIPTION
## OPENEUROPA-3331

### Description

Fixed document not showing the appropriate language and use translated document pattern.

### Change log

- Added:
- Changed: Use translated document pattern.
- Deprecated:
- Removed:
- Fixed: Document not showing correct language.
- Security:

### Commands

```sh
[Insert commands here]

```

