### PR TITLE
EWPP-127: Non required Venue and Organiser fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.1",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "~1.8",
+        "openeuropa/oe_content": "dev-EWPP-125",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "~1.8",


### PR DESCRIPTION
Nothing needs to be changed about Venue and Organiser fields display.
But testing Event content type, **Description** label was displayed even if the field value is empty.

In front the "text" variable equals to :

```
array (size=1)
  '#cache' => 
    array (size=3)
      'contexts' => 
        array (size=0)
          empty
      'tags' => 
        array (size=0)
          empty
      'max-age' => int -1
```

Insofar as the array is not empty, the label is rendered even if no value have to be rendered