### PR TITLE
D8TEWPPE-77: Fix page header test.

### DIFF
--- a/modules/oe_theme_helper/tests/src/Functional/NodeViewRoutesMetadataTest.php
+++ b/modules/oe_theme_helper/tests/src/Functional/NodeViewRoutesMetadataTest.php
@@ -40,15 +40,12 @@ class NodeViewRoutesMetadataTest extends BrowserTestBase {
     parent::setUp();
 
     // Enable oe_theme and set it as default.
-    $this->assertTrue($this->container->get('theme_installer')->install(['oe_theme']));
-    $this->container->get('config.factory')
-      ->getEditable('system.theme')
-      ->set('default', 'oe_theme')
-      ->save();
+    \Drupal::service('theme_installer')->install(['oe_theme']);
+    \Drupal::configFactory()->getEditable('system.theme')->set('default', 'oe_theme')->save();
 
     // Rebuild the ui_pattern definitions to collect the ones provided by
     // oe_theme itself.
-    $this->container->get('plugin.manager.ui_patterns')->clearCachedDefinitions();
+    \Drupal::service('plugin.manager.ui_patterns')->clearCachedDefinitions();
 
     $this->drupalCreateContentType(['type' => 'test', 'name' => 'Moderated'])->save();
 

--- a/patches/@ecl-twig/ec-component-page-header+2.31.0.patch
+++ b/patches/@ecl-twig/ec-component-page-header+2.31.0.patch
@@ -25,3 +25,12 @@ patch-package
    {% endif %}
    {% if _title_wrapper %}
      <div class="ecl-page-header__title-wrapper">
+@@ -95,7 +99,7 @@
+       <p class="ecl-page-header__slogan">{{ _slogan|raw }}</p>
+     {% endif %}
+     {% if _description is not empty %}
+-      <p class="ecl-page-header__description">{{ _description|raw }}</p>
++      <p class="ecl-page-header__description">{{ _description }}</p>
+     {% endif %}
+   {% if _title_wrapper %}
+     </div>


### PR DESCRIPTION
## D8TEWPPE-77

### Description

Fix ecl 2.31.0 with amended patch, because raw filter was added to page header description, this caused the functional test https://github.com/openeuropa/oe_theme/blob/2.x/modules/oe_theme_helper/tests/src/Functional/NodeViewRoutesMetadataTest.php to fails.

### Change log

- Changed:
  - container for service in page header test
  - removed war from description in page header patch


