### PR TITLE
EWPP-193: Update teaser assertion for 2.32.

### DIFF
--- a/tests/PatternAssertions/FileTeaserAssert.php
+++ b/tests/PatternAssertions/FileTeaserAssert.php
@@ -49,17 +49,24 @@ class FileTeaserAssert extends FileTranslationAssert {
   /**
    * Asserts the meta of the pattern.
    *
-   * @param string|null $expected_meta
+   * @param string|null $expected_metas
    *   The expected meta items.
    * @param \Symfony\Component\DomCrawler\Crawler $crawler
    *   The DomCrawler where to check the element.
    */
-  protected function assertMeta($expected_meta, Crawler $crawler): void {
-    if (is_null($expected_meta)) {
+  protected function assertMeta($expected_metas, Crawler $crawler): void {
+    if (is_null($expected_metas)) {
       $this->assertElementNotExists('div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail div.ecl-file__detail-info div.ecl-file__detail-meta span.ecl-file__detail-meta-item', $crawler);
       return;
     }
-    $this->assertElementText($expected_meta, 'div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail div.ecl-file__detail-info div.ecl-file__detail-meta', $crawler);
+    if (!is_array($expected_metas)) {
+      $expected_metas = [$expected_metas];
+    }
+    $meta_items = $crawler->filter('div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail div.ecl-file__detail-info div.ecl-file__detail-meta span.ecl-file__detail-meta-item');
+    self::assertCount(count($expected_metas), $meta_items, 'The expected meta item number does not correspond with the found meta item number.');
+    foreach ($expected_metas as $index => $expected_meta) {
+      self::assertEquals($expected_meta, trim($meta_items->eq($index)->text()), \sprintf('The expected text of the meta number %s does not correspond to the found meta text.', $index));
+    }
   }
 
   /**


### PR DESCRIPTION
## OPENEUROPA-193
### Description

The file teaser pattern assertion needs to be updated to reflect the latest ecl changes.

### Change log

- Added:
- Changed: File teaser assertion.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

