### PR TITLE
EWPP-221: Make label in active filters have the same top margin as the tags.

### DIFF
--- a/templates/patterns/active_search_filters/pattern-active-search-filters.html.twig
+++ b/templates/patterns/active_search_filters/pattern-active-search-filters.html.twig
@@ -5,7 +5,7 @@
  */
 #}
 <div class="active-search-filters ecl-u-d-md-flex">
-  <div class="active-search-filters__name ecl-u-flex-shrink-0 ecl-u-mb-s ecl-u-mr-s">
+  <div class="active-search-filters__name ecl-u-flex-shrink-0 ecl-u-mb-s ecl-u-mr-s ecl-u-pt-xs">
     <span class="ecl-u-text-uppercase">{{ name }}</span>
   </div>
   <div class="active-search-filters__items ecl-u-flex-grow-1">


### PR DESCRIPTION
## EWPP-221

### Description

Make label in active filters have the same top margin as the tags.
### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

