### PR TITLE
EWPP-349: Use view display storage to override organisation displays.

### DIFF
--- a/modules/oe_theme_content_organisation/oe_theme_content_organisation.install
+++ b/modules/oe_theme_content_organisation/oe_theme_content_organisation.install
@@ -26,19 +26,20 @@ function oe_theme_content_organisation_install() {
     'core.entity_view_display.node.oe_organisation.teaser',
   ];
 
+  $view_display_storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
+
   foreach ($displays as $display) {
-    $values = $storage->read($display);
-    $config = EntityViewDisplay::load($values['id']);
-    if (!$config) {
-      $config = EntityViewDisplay::create($values);
-      $config->save();
+    $display_values = $storage->read($display);
+
+    // Take over view display, regardless if it already exists or not.
+    $view_display = EntityViewDisplay::load($display_values['id']);
+    if ($view_display) {
+      $display = $view_display_storage->updateFromStorageRecord($view_display, $display_values);
+      $display->save();
       continue;
     }
 
-    foreach ($values as $key => $value) {
-      $config->set($key, $value);
-    }
-
-    $config->save();
+    $display = $view_display_storage->createFromStorageRecord($display_values);
+    $display->save();
   }
 }


### PR DESCRIPTION
## EWPP-349

### Description

Use view display storage to override node displays.

### Change log

- Added:
- Changed: Use view display storage to override node displays.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

