### PR TITLE
EWPP-384: Add margin to blocks if they are part of the content region.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.5",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "~1.11",
+        "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "~1.9",

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1234,16 +1234,20 @@ function oe_theme_preprocess_responsive_image_formatter(&$variables) {
 }
 
 /**
- * Implements template_preprocess_preprocess_block().
- *
- * For preprocessing default mode of document media type.
+ * Implements template_preprocess_block().
  */
 function oe_theme_preprocess_block(&$variables) {
+  // Style block titles using ECL.
   $variables['title_attributes'] = array_merge_recursive($variables['title_attributes'], [
     'class' => [
       'ecl-u-type-heading-2',
     ],
   ]);
+  // If the block is in the content region add a margin on top.
+  $block = \Drupal::entityTypeManager()->getStorage('block')->load($variables['elements']['#id']);
+  if ($block->getRegion() == 'content') {
+    $variables['attributes']['class'][] = 'ecl-u-mt-s';
+  }
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1243,11 +1243,6 @@ function oe_theme_preprocess_block(&$variables) {
       'ecl-u-type-heading-2',
     ],
   ]);
-  // If the block is in the content region add a margin on top.
-  $block = \Drupal::entityTypeManager()->getStorage('block')->load($variables['elements']['#id']);
-  if ($block->getRegion() == 'content') {
-    $variables['attributes']['class'][] = 'ecl-u-mt-s';
-  }
 }
 
 /**
@@ -1635,4 +1630,15 @@ function oe_theme_preprocess_pattern_organisation_teaser__preview(array &$variab
 function oe_theme_preprocess_field__media__oe_media_iframe__video_iframe__oe_theme_main_content(array &$variables): void {
   // Set video aspect ratio when rendering "oe_theme_main_content" display mode.
   $variables['ratio'] = $variables['element']['#object']->get('oe_media_iframe_ratio')->value;
+}
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ *
+ * Add block region as a suggestion.
+ */
+function oe_theme_theme_suggestions_block_alter(array &$suggestions, array $variables) {
+  /** @var \Drupal\block\Entity\Block $block */
+  $block = \Drupal::entityTypeManager()->getStorage('block')->load($variables['elements']['#id']);
+  $suggestions[] = 'block__region_' . $block->getRegion();
 }

--- a/templates/blocks/block--region-content.html.twig
+++ b/templates/blocks/block--region-content.html.twig
@@ -1,0 +1,18 @@
+{#
+/**
+ * @file
+ * Theme override for blocks in the content region.
+ *
+ * @see ./core/modules/system/templates/block.html.twig
+ */
+#}
+<div{{ attributes.addClass('ecl-u-mb-l') }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {{ content }}
+  {% endblock %}
+</div>

--- a/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
+++ b/templates/compositions/ec-component-navigation-list/navigation-list.html.twig
@@ -14,7 +14,7 @@
  */
 #}
 
-<div>
+<div class="ecl-u-mv-l">
   <h2 class="ecl-u-ma-none ecl-u-type-prolonged-xl ecl-u-type-bold">
     {% include '@ecl-twig/link' with {
       'link': {


### PR DESCRIPTION
## EWPP-384

### Description

Add margin to blocks if they are part of the content region.

### Change log

- Added: Add margin to blocks if they are part of the content region.
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

