### PR TITLE
EWPP-392: Use storage to override view displays for organisations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.5",
         "openeuropa/drupal-core-require-dev": "^8.7",
-        "openeuropa/oe_content": "~1.11",
+        "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "~2.2",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "~1.9",

--- a/modules/oe_theme_content_organisation/oe_theme_content_organisation.install
+++ b/modules/oe_theme_content_organisation/oe_theme_content_organisation.install
@@ -25,20 +25,20 @@ function oe_theme_content_organisation_install() {
     'core.entity_view_display.node.oe_organisation.default',
     'core.entity_view_display.node.oe_organisation.teaser',
   ];
+  $view_display_storage = \Drupal::entityTypeManager()->getStorage('entity_view_display');
 
   foreach ($displays as $display) {
-    $values = $storage->read($display);
-    $config = EntityViewDisplay::load($values['id']);
-    if (!$config) {
-      $config = EntityViewDisplay::create($values);
-      $config->save();
+    $display_values = $storage->read($display);
+
+    // Take over view display, regardless if it already exists or not.
+    $view_display = EntityViewDisplay::load($display_values['id']);
+    if ($view_display) {
+      $display = $view_display_storage->updateFromStorageRecord($view_display, $display_values);
+      $display->save();
       continue;
     }
 
-    foreach ($values as $key => $value) {
-      $config->set($key, $value);
-    }
-
-    $config->save();
+    $display = $view_display_storage->createFromStorageRecord($display_values);
+    $display->save();
   }
 }


### PR DESCRIPTION
## EWPP-392

### Description

Use storage to override view displays for organisations

### Change log

- Added:
- Changed: Use storage to override view displays for organisations
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

