### PR TITLE
EWPP-371: Use DrupalDateTime dates inside DateValueObject objects to translate the dates if needed.

### DIFF
--- a/src/ValueObject/DateValueObject.php
+++ b/src/ValueObject/DateValueObject.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme\ValueObject;
 
-use Drupal\Component\Datetime\DateTimePlus;
+use Drupal\Core\Datetime\DrupalDateTime;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
 use Drupal\datetime_range\Plugin\Field\FieldType\DateRangeItem;
 
@@ -16,14 +16,14 @@ class DateValueObject extends ValueObjectBase implements DateValueObjectInterfac
   /**
    * Start date.
    *
-   * @var \Drupal\Component\Datetime\DateTimePlus
+   * @var \Drupal\Core\Datetime\DrupalDateTime
    */
   protected $start;
 
   /**
    * End date.
    *
-   * @var \Drupal\Component\Datetime\DateTimePlus
+   * @var \Drupal\Core\Datetime\DrupalDateTime
    */
   protected $end;
 
@@ -38,10 +38,10 @@ class DateValueObject extends ValueObjectBase implements DateValueObjectInterfac
    *   Timezone string, e.g. "Europe/Brussels".
    */
   private function __construct(int $start, int $end = NULL, string $timezone = NULL) {
-    $this->start = DateTimePlus::createFromTimestamp($start, $timezone);
+    $this->start = DrupalDateTime::createFromTimestamp($start, $timezone);
 
     if ($end !== NULL) {
-      $this->end = DateTimePlus::createFromTimestamp($end, $timezone);
+      $this->end = DrupalDateTime::createFromTimestamp($end, $timezone);
     }
   }
 
@@ -157,7 +157,7 @@ class DateValueObject extends ValueObjectBase implements DateValueObjectInterfac
         $this->start->format($format) !== $this->end->format($format)
         || $this->start->format($extra) !== $this->end->format($extra)
       )
-      ) {
+    ) {
       $date_interval .= '-' . $this->end->format($format);
     }
 

--- a/tests/Unit/ValueObject/DateValueObjectTest.php
+++ b/tests/Unit/ValueObject/DateValueObjectTest.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\oe_theme\Unit\Patterns;
 
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\oe_theme\ValueObject\DateValueObject;
 use Drupal\Tests\oe_theme\Unit\AbstractUnitTestBase;
 
@@ -18,15 +20,38 @@ class DateValueObjectTest extends AbstractUnitTestBase {
    * @dataProvider dataProvider
    */
   public function testFromArray(array $data, array $expected) {
+    // Mock the string translation service.
+    $language = $this->createMock('\Drupal\Core\Language\LanguageInterface');
+    $language->expects($this->any())
+      ->method('getId')
+      ->willReturn('en');
+    $language_manager = $this->createMock('\Drupal\Core\Language\LanguageManagerInterface');
+    $language_manager->expects($this->any())
+      ->method('getCurrentLanguage')
+      ->willReturn($language);
+
+    // If there is an end date configured, we expect to have double the calls.
+    $expected_calls = $data['end'] ? 6 : 3;
+    $translation = $this->createMock('Drupal\Core\StringTranslation\TranslationInterface');
+    $translation->expects($this->exactly($expected_calls))
+      ->method('translateString')
+      ->willReturnCallback(function (TranslatableMarkup $wrapper) {
+        return $wrapper->getUntranslatedString();
+      });
+    $container = new ContainerBuilder();
+    \Drupal::setContainer($container);
+    $container->set('string_translation', $translation);
+    $container->set('language_manager', $language_manager);
+
     /** @var \Drupal\oe_theme\ValueObject\DateValueObject $date */
     $date = DateValueObject::fromArray($data);
-
     $this->assertEquals($expected['day'], $date->getDay());
     $this->assertEquals($expected['week_day'], $date->getWeekDay());
     $this->assertEquals($expected['month'], $date->getMonth());
     $this->assertEquals($expected['month_name'], $date->getMonthName());
     $this->assertEquals($expected['month_fullname'], $date->getMonthfullName());
     $this->assertEquals($expected['year'], $date->getYear());
+
   }
 
   /**


### PR DESCRIPTION
## EWPP-371

### Description

Dates rendered using DateValueObject are not being translated. To fix that make sure that the DateValueObject uses DrupalDateTime items which will handle the string translation.

### Change log

- Added:
- Changed: Use DrupalDateTime objects inside DateValueObject
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

