### PR TITLE
EWPP-440: Create assertion for Social media links pattern.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ To learn more about EC/EU families and ECL branding visit the [ECL website](http
 
 #### Social media links pattern
 
-In 2.13.0 we introduced new pattern ["Social media links"](./templates/patterns/social_media_links) with two variants:
+In 2.13.0 we introduced a new pattern ["Social media links"](./templates/patterns/social_media_links) with two variants:
 
 - `horizontal`: social media links will be arranged horizontally.
 - `vertical`: social media links will be arranged vertically.
 
-Therefore patterns "Social media links: horizontal" and "Social media links: vertical" are deprecated. Use "Social media
-links" pattern with appropriate variant instead.
+Therefore patterns "Social media links: horizontal" and "Social media links: vertical" are now deprecated. Use the "Social media
+links" pattern with an appropriate variant instead.
 
 ### Upgrade to 2.10.0
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ users can access to the main navigation menu only on sites using standardised EC
 
 To learn more about EC/EU families and ECL branding visit the [ECL website](https://ec.europa.eu/component-library).
 
+### Upgrade to 2.13.0
+
+#### Social media links pattern
+
+In 2.13.0 we introduced new pattern ["Social media links"](./templates/patterns/social_media_links) with two variants:
+
+- `horizontal`: social media links will be arranged horizontally.
+- `vertical`: social media links will be arranged vertically.
+
+Therefore patterns "Social media links: horizontal" and "Social media links: vertical" are deprecated. Use "Social media
+links" pattern with appropriate variant instead.
+
 ### Upgrade to 2.10.0
 
 #### ECL page header

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ users can access to the main navigation menu only on sites using standardised EC
 
 To learn more about EC/EU families and ECL branding visit the [ECL website](https://ec.europa.eu/component-library).
 
-### Upgrade to 2.13.0
+### Upgrade to 2.15.0
 
 #### Social media links pattern
 
-In 2.13.0 we introduced a new pattern ["Social media links"](./templates/patterns/social_media_links) with two variants:
+In 2.15.0 we introduced a new pattern ["Social media links"](./templates/patterns/social_media_links) with two variants:
 
 - `horizontal`: social media links will be arranged horizontally.
 - `vertical`: social media links will be arranged vertically.

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1531,3 +1531,16 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
     '@link' => new FormattableMarkup('<a href="https://europa.eu/" class="ecl-link ecl-link--standalone">europa.eu</a>', []),
   ]);
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function oe_theme_preprocess_patterns_overview_page(&$variables) {
+  // Remove patterns from the list on the "/components" page if they are marked
+  // as hidden.
+  foreach ($variables['patterns'] as $key => $pattern) {
+    if (!empty($pattern['additional']['hidden'])) {
+      unset($variables['patterns'][$key]);
+    }
+  }
+}

--- a/templates/paragraphs/paragraph--oe-social-media-follow.html.twig
+++ b/templates/paragraphs/paragraph--oe-social-media-follow.html.twig
@@ -6,14 +6,8 @@
  * @see ./modules/contrib/paragraphs/templates/paragraph.html.twig
  */
 #}
-{% if variant == 'horizontal' %}
-  {{ pattern('social_media_links_horizontal', {
-    'title': label,
-    'links': links,
-  }) }}
-{% else %}
-  {{ pattern('social_media_links_vertical', {
-    'title': label,
-    'links': links,
-  }) }}
-{% endif %}
+{{ pattern('social_media_links', {
+  'variant': variant,
+  'title': label,
+  'links': links,
+}) }}

--- a/templates/pattern-previews/pattern-social-media-links--variant-vertical--preview.html.twig
+++ b/templates/pattern-previews/pattern-social-media-links--variant-vertical--preview.html.twig
@@ -5,5 +5,5 @@
  */
 #}
 <div style="max-width: 400px">
-  {% include 'pattern-social-media-links-vertical.html.twig' %}
+  {% include 'pattern-social-media-links.html.twig' %}
 </div>

--- a/templates/patterns/social_media_links/pattern-social-media-links-horizontal.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links-horizontal.html.twig
@@ -5,35 +5,8 @@
  */
 #}
 
-{% set _links = [] %}
-{% for link in links %}
-  {% set _link = {
-    path: link.url,
-    label: link.label
-  } %}
-  {% if link.service is not empty %}
-    {% set _link = _link|merge({
-      icon_position: 'before',
-      icon: [
-        {
-          path: ecl_social_icon_path,
-          name: link.service,
-          size: 'xl',
-          extra_classes: 'ecl-social-media-follow__icon',
-        },
-        {
-          path: ecl_social_icon_path,
-          name: link.service ~ '_hover',
-          size: 'xl',
-          extra_classes: 'ecl-social-media-follow__icon-hover',
-        }
-      ]
-    }) %}
-  {% endif %}
-  {% set _links = _links|merge([_link]) %}
-{% endfor %}
-
-{% include '@ecl-twig/social-media-follow' with {
-  'description': title,
-  'links': _links,
-} %}
+{{ pattern('social_media_links', {
+  'variant': 'horizontal',
+  'title': title,
+  'links': links,
+}) }}

--- a/templates/patterns/social_media_links/pattern-social-media-links-vertical.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links-vertical.html.twig
@@ -5,36 +5,8 @@
  */
 #}
 
-{% set _links = [] %}
-{% for link in links %}
-  {% set _link = {
-    path: link.url,
-    label: link.label
-  } %}
-  {% if link.service is not empty %}
-    {% set _link = _link|merge({
-      icon_position: 'before',
-      icon: [
-        {
-          path: ecl_social_icon_path,
-          name: link.service,
-          size: 'xl',
-          extra_classes: 'ecl-social-media-follow__icon',
-        },
-        {
-          path: ecl_social_icon_path,
-          name: link.service ~ '_hover',
-          size: 'xl',
-          extra_classes: 'ecl-social-media-follow__icon-hover',
-        }
-      ]
-    }) %}
-  {% endif %}
-  {% set _links = _links|merge([_link]) %}
-{% endfor %}
-
-{% include '@ecl-twig/social-media-follow' with {
+{{ pattern('social_media_links', {
   'variant': 'vertical',
-  'description': title,
-  'links': _links,
-} %}
+  'title': title,
+  'links': links,
+}) }}

--- a/templates/patterns/social_media_links/pattern-social-media-links.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links.html.twig
@@ -1,0 +1,39 @@
+{#
+/**
+ * @file
+ * Social media links.
+ */
+#}
+
+{% set _links = [] %}
+{% for link in links %}
+  {% set _link = {
+    path: link.url,
+    label: link.label
+  } %}
+  {% if link.service is not empty %}
+    {% set _link = _link|merge({
+      icon_position: 'before',
+      icon: [
+        {
+          path: ecl_social_icon_path,
+          name: link.service,
+          size: 'xl',
+          extra_classes: 'ecl-social-media-follow__icon',
+        },
+        {
+          path: ecl_social_icon_path,
+          name: link.service ~ '_hover',
+          size: 'xl',
+          extra_classes: 'ecl-social-media-follow__icon-hover',
+        }
+      ]
+    }) %}
+  {% endif %}
+  {% set _links = _links|merge([_link]) %}
+{% endfor %}
+
+{% include '@ecl-twig/social-media-follow' with {
+  'description': title,
+  'links': _links,
+} %}

--- a/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
+++ b/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
@@ -28,3 +28,5 @@ social_media_links:
         - service: "instagram"
           label: "Instagram"
           url: "#"
+        - label: "See more"
+          url: "#"

--- a/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
+++ b/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
@@ -1,13 +1,13 @@
 social_media_links:
   label: "Social media links"
-  description: "Social network icon with link of label."
+  description: "Showcases a list of social media links with their respective icons."
   variants:
     horizontal:
       label: "Horizontal"
-      description: "It will align the field items horizontally."
+      description: "Social media links will be arranged horizontally."
     vertical:
       label: "Vertical"
-      description: "It will align the field items vertically."
+      description: "Social media links will be arranged vertically."
   fields:
     title:
       type: "text"

--- a/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
+++ b/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
@@ -1,6 +1,13 @@
-social_media_links_vertical:
-  label: "Social media links: vertical (Deprecated)"
+social_media_links:
+  label: "Social media links"
   description: "Social network icon with link of label."
+  variants:
+    horizontal:
+      label: "Horizontal"
+      description: "It will align the field items horizontally."
+    vertical:
+      label: "Vertical"
+      description: "It will align the field items vertically."
   fields:
     title:
       type: "text"
@@ -21,6 +28,3 @@ social_media_links_vertical:
         - service: "instagram"
           label: "Instagram"
           url: "#"
-  additional:
-    style: "max-width: 400px"
-    hidden: true

--- a/templates/patterns/social_media_links/social_media_links_horizontal.ui_patterns.yml
+++ b/templates/patterns/social_media_links/social_media_links_horizontal.ui_patterns.yml
@@ -1,5 +1,5 @@
 social_media_links_horizontal:
-  label: "Social media links: horizontal"
+  label: "Social media links: horizontal (Deprecated)"
   description: "Social network icon with link of label, displayed horizontally."
   fields:
     title:
@@ -21,3 +21,5 @@ social_media_links_horizontal:
         - service: "instagram"
           label: "Instagram"
           url: "#"
+  additional:
+    hidden: true

--- a/tests/PatternAssertions/SocialMediaLinksAssert.php
+++ b/tests/PatternAssertions/SocialMediaLinksAssert.php
@@ -68,11 +68,11 @@ class SocialMediaLinksAssert extends BasePatternAssert {
     if (in_array('ecl-social-media-follow--vertical', $existing_classes)) {
       return 'vertical';
     }
-    throw new Exception('Variant of social media links pattern is not identified.');
+    throw new Exception('Variant of social media links pattern could not be identified.');
   }
 
   /**
-   * Asserts the links of the pattern.
+   * Asserts the links of social media follow.
    *
    * @param array $expected_items
    *   The expected item values.

--- a/tests/PatternAssertions/SocialMediaLinksAssert.php
+++ b/tests/PatternAssertions/SocialMediaLinksAssert.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\PatternAssertions;
+
+use Symfony\Component\DomCrawler\Crawler;
+use PHPUnit\Framework\Exception;
+
+/**
+ * Assertions for the field list pattern.
+ *
+ * @package Drupal\Tests\oe_theme\PatternAssertions
+ */
+class SocialMediaLinksAssert extends BasePatternAssert {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAssertions(string $variant): array {
+    return [
+      'title' => [
+        [$this, 'assertElementText'],
+        'div' . $this->getBaseItemClass($variant) . ' p.ecl-social-media-follow__description',
+      ],
+      'links' => [
+        [$this, 'assertLinks'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertBaseElements(string $html, string $variant): void {
+    $crawler = new Crawler($html);
+    $field_list_container = $crawler->filter('div' . $this->getBaseItemClass($variant));
+    self::assertCount(1, $field_list_container);
+  }
+
+  /**
+   * Returns the base CSS selector for a field item depending on the variant.
+   *
+   * @param string $variant
+   *   The variant being checked.
+   *
+   * @return string
+   *   The base selector for the variant.
+   */
+  protected function getBaseItemClass(string $variant): string {
+    if ($variant === 'horizontal') {
+      return '.ecl-social-media-follow.ecl-social-media-follow--horizontal';
+    }
+    return '.ecl-social-media-follow.ecl-social-media-follow--vertical';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getPatternVariant(string $html): string {
+    $crawler = new Crawler($html);
+    $field_list_container = $crawler->filter('div.ecl-social-media-follow');
+    $existing_classes = $field_list_container->attr('class');
+    $existing_classes = explode(' ', $existing_classes);
+    if (in_array('ecl-social-media-follow--horizontal', $existing_classes)) {
+      return 'horizontal';
+    }
+    if (in_array('ecl-social-media-follow--vertical', $existing_classes)) {
+      return 'vertical';
+    }
+    throw new Exception('Variant of social media links pattern is not identified.');
+  }
+
+  /**
+   * Asserts the links of the pattern.
+   *
+   * @param array $expected_items
+   *   The expected item values.
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   The DomCrawler where to check the element.
+   */
+  protected function assertLinks(array $expected_items, Crawler $crawler): void {
+    $li_items = $crawler->filter('li.ecl-social-media-follow__item');
+    self::assertCount(count($expected_items), $li_items);
+
+    foreach ($expected_items as $index => $expected_item) {
+      $li_item = $li_items->eq($index);
+      if (empty($expected_item['service'])) {
+        // Service icon is absent.
+        $link_element = $label_element = $li_item->filter('a.ecl-link.ecl-link--standalone.ecl-social-media-follow__link');
+      }
+      else {
+        // Service icon exists.
+        $link_element = $li_item->filter('a.ecl-link.ecl-link--standalone.ecl-link--icon.ecl-link--icon-before.ecl-social-media-follow__link');
+        $label_element = $link_element->filter('span.ecl-link__label');
+        $icon_social_file = 'icons-social.svg#';
+        $svg = $link_element->filter('svg.ecl-icon.ecl-icon--xl.ecl-link__icon.ecl-social-media-follow__icon use');
+        self::assertContains($icon_social_file . $expected_item['service'], $svg->attr('xlink:href'));
+        $svg_hover = $link_element->filter('svg.ecl-icon.ecl-icon--xl.ecl-link__icon.ecl-social-media-follow__icon-hover use');
+        self::assertContains($icon_social_file . $expected_item['service'] . '_hover', $svg_hover->attr('xlink:href'));
+      }
+
+      self::assertEquals($expected_item['label'], trim($label_element->text()));
+      self::assertEquals($expected_item['url'], $link_element->attr('href'));
+    }
+  }
+
+}

--- a/tests/PatternAssertions/SocialMediaLinksAssert.php
+++ b/tests/PatternAssertions/SocialMediaLinksAssert.php
@@ -72,7 +72,7 @@ class SocialMediaLinksAssert extends BasePatternAssert {
   }
 
   /**
-   * Asserts the links of social media follow.
+   * Asserts the links of the social media links pattern.
    *
    * @param array $expected_items
    *   The expected item values.

--- a/tests/PatternAssertions/SocialMediaLinksAssert.php
+++ b/tests/PatternAssertions/SocialMediaLinksAssert.php
@@ -8,7 +8,7 @@ use Symfony\Component\DomCrawler\Crawler;
 use PHPUnit\Framework\Exception;
 
 /**
- * Assertions for the field list pattern.
+ * Assertions for the social media link pattern.
  *
  * @package Drupal\Tests\oe_theme\PatternAssertions
  */
@@ -39,7 +39,7 @@ class SocialMediaLinksAssert extends BasePatternAssert {
   }
 
   /**
-   * Returns the base CSS selector for a field item depending on the variant.
+   * Returns the base CSS selector of a pattern depending on the variant.
    *
    * @param string $variant
    *   The variant being checked.
@@ -93,11 +93,10 @@ class SocialMediaLinksAssert extends BasePatternAssert {
         // Service icon exists.
         $link_element = $li_item->filter('a.ecl-link.ecl-link--standalone.ecl-link--icon.ecl-link--icon-before.ecl-social-media-follow__link');
         $label_element = $link_element->filter('span.ecl-link__label');
-        $icon_social_file = 'icons-social.svg#';
         $svg = $link_element->filter('svg.ecl-icon.ecl-icon--xl.ecl-link__icon.ecl-social-media-follow__icon use');
-        self::assertContains($icon_social_file . $expected_item['service'], $svg->attr('xlink:href'));
+        self::assertContains('icons-social.svg#' . $expected_item['service'], $svg->attr('xlink:href'));
         $svg_hover = $link_element->filter('svg.ecl-icon.ecl-icon--xl.ecl-link__icon.ecl-social-media-follow__icon-hover use');
-        self::assertContains($icon_social_file . $expected_item['service'] . '_hover', $svg_hover->attr('xlink:href'));
+        self::assertContains('icons-social.svg#' . $expected_item['service'] . '_hover', $svg_hover->attr('xlink:href'));
       }
 
       self::assertEquals($expected_item['label'], trim($label_element->text()));


### PR DESCRIPTION
## EWPP-440

### Description

1. Merged Social media links horizontal and vertical to one pattern as described in https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OPENEUROPA-2489.

2. SocialMediaLinksAssert has been added to test Social media links pattern.

## Example

```
    $html = $this->assertSession()->elementExists('css', '.ecl-social-media-follow')->getOuterHtml();
    $assert = new SocialMediaLinksAssert();
    $expected_values = [
      'title' => 'Social media',
      'links' => [
        [
          'service' => 'facebook',
          'label' => 'Social media general_contact',
          'url' => 'http://www.example.com/social_media_general_contact',
        ]
      ]
    ];
    $assert->assertPattern($expected_values, $html);
```