### PR TITLE
EWPP-468: Add site-specific other links to corporate footers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "openeuropa/code-review": "~1.5",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/oe_content": "dev-master",
-        "openeuropa/oe_corporate_blocks": "3.x-dev",
+        "openeuropa/oe_corporate_blocks": "dev-EWPP-468",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "dev-master as 1.9",
         "openeuropa/oe_multilingual": "~1.5",

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "openeuropa/code-review": "~1.5",
         "openeuropa/drupal-core-require-dev": "^8.7",
         "openeuropa/oe_content": "dev-master",
-        "openeuropa/oe_corporate_blocks": "dev-EWPP-468",
+        "openeuropa/oe_corporate_blocks": "3.x-dev",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta1",
         "openeuropa/oe_media": "dev-master as 1.9",
         "openeuropa/oe_multilingual": "~1.5",

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -676,6 +676,17 @@ class TwigExtension extends \Twig_Extension {
         ];
       }
 
+      if (!empty($link['social_network'])) {
+        $ecl_link['link']['icon_position'] = 'before';
+        $ecl_link += [
+          'icon' => [
+            'path' => $context['ecl_icon_path'],
+            'type' => 'branded',
+            'name' => $link['social_network'],
+          ],
+        ];
+      }
+
       $ecl_links[] = $ecl_link;
     }
 

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -76,42 +76,44 @@
   }]) %}
 {% endif %}
 
-{% set _sections = [
-  {
-    'title': {
+{% block content %}
+  {% set _sections = [
+    {
+      'title': {
       'link': {
         'label': site_specific_footer.site_identity,
         'path': url('<front>'),
       }
     },
-    'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
-    'section_id': 1,
-  },
-  _section_2,
-  _section_3,
-  {
-    'section_id': 6,
-    'list_class_name': 'ecl-footer-standardised__list--condensed',
-  },
-  {
-    'title': {
+      'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
+      'section_id': 1,
+    },
+    _section_2,
+    _section_3,
+    {
+      'section_id': 6,
+      'list_class_name': 'ecl-footer-standardised__list--condensed',
+    },
+    {
+      'title': {
       'link': {
         'label': corporate_footer.corporate_site_link.label,
         'path': corporate_footer.corporate_site_link.href,
       },
     },
-    'section_id': 7,
-  },
-  {
-    'links': ecl_footer_links(corporate_footer.service_navigation),
-    'section_id': 8,
-  },
-  {
-    'links': ecl_footer_links(corporate_footer.legal_navigation),
-    'section_id': 9,
-  },
-] %}
+      'section_id': 7,
+    },
+    {
+      'links': ecl_footer_links(corporate_footer.service_navigation),
+      'section_id': 8,
+    },
+    {
+      'links': ecl_footer_links(corporate_footer.legal_navigation),
+      'section_id': 9,
+    },
+  ] %}
 
-{% include '@ecl-twig/footer-standardised' with {
-  'sections': _sections,
-} %}
+  {% include '@ecl-twig/footer-standardised' with {
+    'sections': _sections,
+  } %}
+{% endblock %}

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -51,7 +51,7 @@
 
   {% endif %}
 
-  {# Follow section must always be the last on on the left. #}
+  {# Follow section must always be the last on the left. #}
   {% set _section_2 = _section_2|merge([{
     'title': 'Follow us on'|t,
     'links': ecl_footer_links(site_specific_footer.social_links),

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -11,53 +11,70 @@
  */
 #}
 
-{# Section 2 will contain first general link and the social links. #}
-
 {% set _section_2 = [] %}
-
-{% set section = site_specific_footer.other_links|first %}
-
-{% set _section_2 = _section_2|merge([{
-  'title': section.links ? section.label,
-  'links': section.links ? ecl_footer_links(section.links),
-  'section_id': 2,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{% set _section_2 = _section_2|merge([{
-  'title': site_specific_footer.social_links ? 'Follow us on'|t,
-  'links': site_specific_footer.social_links ? ecl_footer_links(site_specific_footer.social_links),
-  'section_id': 2,
-  'list_class_name': 'ecl-footer-standardised__list--inline',
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{# Section 3 will contain the remaining general links. #}
-
 {% set _section_3 = [] %}
 
-{% for section in site_specific_footer.other_links|slice(1) %}
+{# First we parse the other_links, we make a simple grid. #}
+{% for section in site_specific_footer.other_links %}
+  {% if loop.index is odd %}
+    {% set _section_2 = _section_2|merge([{
+      'title': section.label,
+      'links': ecl_footer_links(section.links),
+      'section_id': 2,
+      'title_class_name': 'ecl-footer-standardised__title--separator',
+    }]) %}
+  {% else %}
+    {% set _section_3 = _section_3|merge([{
+      'title': section.label,
+      'links': ecl_footer_links(section.links),
+      'section_id': 3,
+      'title_class_name': 'ecl-footer-standardised__title--separator',
+    }]) %}
+  {% endif %}
+{% endfor %}
 
+{# When follow section is present. #}
+{% if site_specific_footer.social_links is not empty %}
+  {# If section numbers are odd, then we flip the last row so to have the follow as first. #}
+  {% if _section_2|length > _section_3|length %}
+    {% set _last_in_section_2 = _section_2|last %}
+
+    {# Compensate for bug in twig where _section_2[1:] returns empty if _section_2|length is 1. #}
+    {% if _last_in_section_2 is empty %}
+      {% set _last_in_section_2 = _section_2[0] %}
+      {% set _section_2 = [] %}
+    {% endif %}
+
+    {% set _section_2 = _section_2[:_section_2|length - 1] %}
+    {% set _last_in_section_2 = _last_in_section_2|merge({'section_id': 3}) %}
+    {% set _section_3 = _section_3|merge([_last_in_section_2]) %}
+
+  {% endif %}
+
+  {# Follow section must always be the last on on the left. #}
+  {% set _section_2 = _section_2|merge([{
+    'title': 'Follow us on'|t,
+    'links': ecl_footer_links(site_specific_footer.social_links),
+    'section_id': 2,
+    'list_class_name': 'ecl-footer-standardised__list--inline',
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+{% endif %}
+
+{# Section 2 and 3 needs minimum 2 items to display. #}
+{% if _section_2|length == 1 %}
+  {% set _section_2 = _section_2|merge([{
+    'section_id': 2,
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+{% endif %}
+
+{% if _section_3|length == 1 %}
   {% set _section_3 = _section_3|merge([{
-    'title': section.links ? section.label,
-    'links': section.links ? ecl_footer_links(section.links),
     'section_id': 3,
     'title_class_name': 'ecl-footer-standardised__title--separator',
   }]) %}
-
-{% endfor %}
-
-{# Section 2 and 3 needs minimum 2 items to display. #}
-
-{% set _section_3 = _section_3|merge([{
-  'section_id': 3,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{% set _section_2 = _section_2|merge([{
-  'section_id': 2,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
+{% endif %}
 
 {% set _sections = [
   {

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -11,6 +11,54 @@
  */
 #}
 
+{# Section 2 will contain first general link and the social links. #}
+
+{% set _section_2 = [] %}
+
+{% set section = site_specific_footer.other_links|first %}
+
+{% set _section_2 = _section_2|merge([{
+  'title': section.links ? section.label,
+  'links': section.links ? ecl_footer_links(section.links),
+  'section_id': 2,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{% set _section_2 = _section_2|merge([{
+  'title': site_specific_footer.social_links ? 'Follow us on'|t,
+  'links': site_specific_footer.social_links ? ecl_footer_links(site_specific_footer.social_links),
+  'section_id': 2,
+  'list_class_name': 'ecl-footer-standardised__list--inline',
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{# Section 3 will contain the remaining general links. #}
+
+{% set _section_3 = [] %}
+
+{% for section in site_specific_footer.other_links|slice(1) %}
+
+  {% set _section_3 = _section_3|merge([{
+    'title': section.links ? section.label,
+    'links': section.links ? ecl_footer_links(section.links),
+    'section_id': 3,
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+
+{% endfor %}
+
+{# Section 2 and 3 needs minimum 2 items to display. #}
+
+{% set _section_3 = _section_3|merge([{
+  'section_id': 3,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{% set _section_2 = _section_2|merge([{
+  'section_id': 2,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
 {% set _sections = [
   {
     'title': {
@@ -22,27 +70,8 @@
     'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
     'section_id': 1,
   },
-  [
-    {
-      'section_id': 2,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-    {
-      'section_id': 2,
-      'list_class_name': 'ecl-footer-standardised__list--inline',
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-  ],
-  [
-    {
-      'section_id': 3,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-    {
-      'section_id': 3,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-  ],
+  _section_2,
+  _section_3,
   {
     'section_id': 6,
     'list_class_name': 'ecl-footer-standardised__list--condensed',

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -11,127 +11,65 @@
  */
 #}
 
-{% set _section_2 = [] %}
-{% set _section_3 = [] %}
+{% extends "@oe_theme/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig" %}
 
-{# First we parse the other_links, we make a simple grid. #}
-{% for section in site_specific_footer.other_links %}
-  {% if loop.index is odd %}
-    {% set _section_2 = _section_2|merge([{
-      'title': section.label,
-      'links': ecl_footer_links(section.links),
-      'section_id': 2,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    }]) %}
-  {% else %}
-    {% set _section_3 = _section_3|merge([{
-      'title': section.label,
-      'links': ecl_footer_links(section.links),
-      'section_id': 3,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    }]) %}
-  {% endif %}
-{% endfor %}
-
-{# When follow section is present. #}
-{% if site_specific_footer.social_links is not empty %}
-  {# If section numbers are odd, then we flip the last row so to have the follow as first. #}
-  {% if _section_2|length > _section_3|length %}
-    {% set _last_in_section_2 = _section_2|last %}
-
-    {# Compensate for bug in twig where _section_2[1:] returns empty if _section_2|length is 1. #}
-    {% if _last_in_section_2 is empty %}
-      {% set _last_in_section_2 = _section_2[0] %}
-      {% set _section_2 = [] %}
-    {% endif %}
-
-    {% set _section_2 = _section_2[:_section_2|length - 1] %}
-    {% set _last_in_section_2 = _last_in_section_2|merge({'section_id': 3}) %}
-    {% set _section_3 = _section_3|merge([_last_in_section_2]) %}
-
-  {% endif %}
-
-  {# Follow section must always be the last on the left. #}
-  {% set _section_2 = _section_2|merge([{
-    'title': 'Follow us on'|t,
-    'links': ecl_footer_links(site_specific_footer.social_links),
-    'section_id': 2,
-    'list_class_name': 'ecl-footer-standardised__list--inline',
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }]) %}
-{% endif %}
-
-{# Section 2 and 3 needs minimum 2 items to display. #}
-{% if _section_2|length == 1 %}
-  {% set _section_2 = _section_2|merge([{
-    'section_id': 2,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }]) %}
-{% endif %}
-
-{% if _section_3|length == 1 %}
-  {% set _section_3 = _section_3|merge([{
-    'section_id': 3,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }]) %}
-{% endif %}
-
-{% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
-
-{% set _sections = [
-  {
-    'title': {
+{% block content %}
+  {% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
+  {% set _sections = [
+    {
+      'title': {
       'link': {
         'label': site_specific_footer.site_identity,
         'path': url('<front>'),
       }
     },
-    'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
-    'section_id': 1,
-  },
-  _section_2,
-  _section_3,
-  {
-    'section_id': 6,
-  },
-  {
-    'logo': {
+      'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
+      'section_id': 1,
+    },
+    _section_2,
+    _section_3,
+    {
+      'section_id': 6,
+    },
+    {
+      'logo': {
       'path': 'https://europa.eu/',
       'language': current_language_id,
       'src_mobile': _logo_path,
       'src_desktop': _logo_path,
     },
-    'description': logo_description,
-    'section_id': 7,
-  },
-  [
-    {
-      'title': corporate_footer.contact_title,
-      'links': ecl_footer_links(corporate_footer.contact),
-      'section_id': 8,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
+      'description': logo_description,
+      'section_id': 7,
     },
+    [
+      {
+        'title': corporate_footer.contact_title,
+        'links': ecl_footer_links(corporate_footer.contact),
+        'section_id': 8,
+        'title_class_name': 'ecl-footer-standardised__title--separator',
+      },
+      {
+        'title': corporate_footer.social_media_title,
+        'links': ecl_footer_links(corporate_footer.social_media),
+        'section_id': 8,
+        'title_class_name': 'ecl-footer-standardised__title--separator',
+      },
+      {
+        'title': corporate_footer.legal_links_title,
+        'links': ecl_footer_links(corporate_footer.legal_links),
+        'section_id': 8,
+        'title_class_name': 'ecl-footer-standardised__title--separator',
+      }
+    ],
     {
-      'title': corporate_footer.social_media_title,
-      'links': ecl_footer_links(corporate_footer.social_media),
-      'section_id': 8,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-    {
-      'title': corporate_footer.legal_links_title,
-      'links': ecl_footer_links(corporate_footer.legal_links),
-      'section_id': 8,
+      'title': corporate_footer.institution_links_title,
+      'links': ecl_footer_links(corporate_footer.institution_links),
+      'section_id': 9,
       'title_class_name': 'ecl-footer-standardised__title--separator',
     }
-  ],
-  {
-    'title': corporate_footer.institution_links_title,
-    'links': ecl_footer_links(corporate_footer.institution_links),
-    'section_id': 9,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }
-] %}
+  ] %}
 
-{% include '@ecl-twig/footer-standardised' with {
-  'sections': _sections,
-} %}
+  {% include '@ecl-twig/footer-standardised' with {
+    'sections': _sections,
+  } %}
+{% endblock %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -51,7 +51,7 @@
 
   {% endif %}
 
-  {# Follow section must always be the last on on the left. #}
+  {# Follow section must always be the last on the left. #}
   {% set _section_2 = _section_2|merge([{
     'title': 'Follow us on'|t,
     'links': ecl_footer_links(site_specific_footer.social_links),

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -11,6 +11,53 @@
  */
 #}
 
+{# Section 2 will contain first general link and the social links. #}
+
+{% set _section_2 = [] %}
+
+{% set section = site_specific_footer.other_links|first %}
+
+{% set _section_2 = _section_2|merge([{
+  'title': section.links ? section.label,
+  'links': section.links ? ecl_footer_links(section.links),
+  'section_id': 2,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{% set _section_2 = _section_2|merge([{
+  'title': site_specific_footer.social_links ? 'Follow us on'|t,
+  'links': site_specific_footer.social_links ? ecl_footer_links(site_specific_footer.social_links),
+  'section_id': 2,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{# Section 3 will contain the remaining general links. #}
+
+{% set _section_3 = [] %}
+
+{% for section in site_specific_footer.other_links|slice(1) %}
+
+  {% set _section_3 = _section_3|merge([{
+    'title': section.links ? section.label,
+    'links': section.links ? ecl_footer_links(section.links),
+    'section_id': 3,
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+
+{% endfor %}
+
+{# Section 2 and 3 needs minimum 2 items to display. #}
+
+{% set _section_3 = _section_3|merge([{
+  'section_id': 3,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
+{% set _section_2 = _section_2|merge([{
+  'section_id': 2,
+  'title_class_name': 'ecl-footer-standardised__title--separator',
+}]) %}
+
 {% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
 
 {% set _sections = [
@@ -24,20 +71,8 @@
     'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
     'section_id': 1,
   },
-  [
-    {
-      'section_id': 2,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    },
-    {
-      'section_id': 2,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    }
-  ],
-  {
-    'section_id': 3,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  },
+  _section_2,
+  _section_3,
   {
     'section_id': 6,
   },

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -11,52 +11,70 @@
  */
 #}
 
-{# Section 2 will contain first general link and the social links. #}
-
 {% set _section_2 = [] %}
-
-{% set section = site_specific_footer.other_links|first %}
-
-{% set _section_2 = _section_2|merge([{
-  'title': section.links ? section.label,
-  'links': section.links ? ecl_footer_links(section.links),
-  'section_id': 2,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{% set _section_2 = _section_2|merge([{
-  'title': site_specific_footer.social_links ? 'Follow us on'|t,
-  'links': site_specific_footer.social_links ? ecl_footer_links(site_specific_footer.social_links),
-  'section_id': 2,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{# Section 3 will contain the remaining general links. #}
-
 {% set _section_3 = [] %}
 
-{% for section in site_specific_footer.other_links|slice(1) %}
+{# First we parse the other_links, we make a simple grid. #}
+{% for section in site_specific_footer.other_links %}
+  {% if loop.index is odd %}
+    {% set _section_2 = _section_2|merge([{
+      'title': section.label,
+      'links': ecl_footer_links(section.links),
+      'section_id': 2,
+      'title_class_name': 'ecl-footer-standardised__title--separator',
+    }]) %}
+  {% else %}
+    {% set _section_3 = _section_3|merge([{
+      'title': section.label,
+      'links': ecl_footer_links(section.links),
+      'section_id': 3,
+      'title_class_name': 'ecl-footer-standardised__title--separator',
+    }]) %}
+  {% endif %}
+{% endfor %}
 
+{# When follow section is present. #}
+{% if site_specific_footer.social_links is not empty %}
+  {# If section numbers are odd, then we flip the last row so to have the follow as first. #}
+  {% if _section_2|length > _section_3|length %}
+    {% set _last_in_section_2 = _section_2|last %}
+
+    {# Compensate for bug in twig where _section_2[1:] returns empty if _section_2|length is 1. #}
+    {% if _last_in_section_2 is empty %}
+      {% set _last_in_section_2 = _section_2[0] %}
+      {% set _section_2 = [] %}
+    {% endif %}
+
+    {% set _section_2 = _section_2[:_section_2|length - 1] %}
+    {% set _last_in_section_2 = _last_in_section_2|merge({'section_id': 3}) %}
+    {% set _section_3 = _section_3|merge([_last_in_section_2]) %}
+
+  {% endif %}
+
+  {# Follow section must always be the last on on the left. #}
+  {% set _section_2 = _section_2|merge([{
+    'title': 'Follow us on'|t,
+    'links': ecl_footer_links(site_specific_footer.social_links),
+    'section_id': 2,
+    'list_class_name': 'ecl-footer-standardised__list--inline',
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+{% endif %}
+
+{# Section 2 and 3 needs minimum 2 items to display. #}
+{% if _section_2|length == 1 %}
+  {% set _section_2 = _section_2|merge([{
+    'section_id': 2,
+    'title_class_name': 'ecl-footer-standardised__title--separator',
+  }]) %}
+{% endif %}
+
+{% if _section_3|length == 1 %}
   {% set _section_3 = _section_3|merge([{
-    'title': section.links ? section.label,
-    'links': section.links ? ecl_footer_links(section.links),
     'section_id': 3,
     'title_class_name': 'ecl-footer-standardised__title--separator',
   }]) %}
-
-{% endfor %}
-
-{# Section 2 and 3 needs minimum 2 items to display. #}
-
-{% set _section_3 = _section_3|merge([{
-  'section_id': 3,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
-
-{% set _section_2 = _section_2|merge([{
-  'section_id': 2,
-  'title_class_name': 'ecl-footer-standardised__title--separator',
-}]) %}
+{% endif %}
 
 {% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
 

--- a/tests/Functional/CorporateFooterRenderTest.php
+++ b/tests/Functional/CorporateFooterRenderTest.php
@@ -124,7 +124,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $assert = $this->assertSession();
 
     // Make sure that footer block is present.
-    $this->assertFooterPresence('standardised', 11);
+    $this->assertFooterPresence('standardised', 7);
 
     $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section1');
 
@@ -170,58 +170,6 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $actual = $section->find('css', 'div.ecl-footer-standardised__description');
     $this->assertEquals('This site is managed by the DG XI – Internal Market', $actual->getText());
-
-    // Add custom footer links.
-    $this->createGeneralLink('Custom contact 1', 'contact_us');
-    $this->createGeneralLink('Custom about 1', 'about_us');
-    $this->createGeneralLink('Custom related 1', 'related_sites');
-    $this->createSocialLink('Social 1', 'facebook');
-    $this->createSocialLink('Social 2', 'instagram');
-    $this->drupalGet('<front>');
-
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
-
-    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
-    $this->assertEquals('Contact us', $actual->getText());
-
-    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
-    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
-    $this->assertListLink($actual, 'standardised', $expected);
-
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
-
-    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
-    $this->assertEquals('Follow us on', $actual->getText());
-
-    $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
-    $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
-    $this->assertSocialLink($social_label, $social_link, $expected);
-
-    $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
-    $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
-    $this->assertSocialLink($social_label, $social_link, $expected);
-
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
-
-    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
-    $this->assertEquals('About us', $actual->getText());
-
-    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
-    $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
-    $this->assertListLink($actual, 'standardised', $expected);
-
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
-
-    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
-    $this->assertEquals('Related sites', $actual->getText());
-
-    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
-    $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
-    $this->assertListLink($actual, 'standardised', $expected);
 
     // Test European Union footer core block rendering.
     $this->configFactory->getEditable('oe_theme.settings')->set('component_library', 'eu')->save();
@@ -312,7 +260,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $assert = $this->assertSession();
 
     // Make sure that footer block is present.
-    $this->assertFooterPresence('standardised', 14);
+    $this->assertFooterPresence('standardised', 10);
 
     $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section1');
 
@@ -384,10 +332,84 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'standardised', $expected);
     }
 
-    // Add new section and more footer links.
-    $this->createSection('Section 1', 'section_1');
-    $this->createGeneralLink('Custom link 1', 'section_1');
-    $this->createSocialLink('Social 3', 'rss');
+    // Add a few custom footer links, one by one to assert section distripution.
+    $this->createGeneralLink('Custom contact 1', 'contact_us');
+    $this->drupalGet('<front>');
+
+    // Assert section 2 (left column) has the item,
+    // and section 3 (right column) is empty.
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Contact us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $section = $assert->elementNotExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+
+    // Assert each sections 2 and 3 each have 1 item.
+    $this->createGeneralLink('Custom about 1', 'about_us');
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Contact us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('About us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Add one more, assert odd goes into section 2, even goes into section 3.
+    $this->createGeneralLink('Custom related 1', 'related_sites');
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Contact us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Related sites', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('About us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+
+    // Add the follow us, assert it goes last, into the left column.
+    // We have 3 sub-sections plus follow, distribution should be 2 and 2.
+    $this->createSocialLink('Social 1', 'facebook');
+    $this->createSocialLink('Social 2', 'instagram');
     $this->drupalGet('<front>');
 
     $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
@@ -415,9 +437,66 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
-    $social_link = $subsection->find('css', 'ul li:nth-child(3) > a');
-    $social_label = $subsection->find('css', 'ul li:nth-child(3) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 3', 'href' => 'http://example.com/social-3'];
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('About us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+
+    // Assert previous last in section 2 moved to the right into section 3.
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Related sites', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Assert adding a custom section in backend appears,
+    // and is placed in the footer on the right side in section 3.
+    $this->createSection('section_1', 'Section 1');
+    $this->createGeneralLink('Custom link 1', 'section_1');
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Contact us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Since we have an even number there is no switch,
+    // assert Related is back in section 2.
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Related sites', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Here we assert Follow us is still on the left in section 2.
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Follow us on', $actual->getText());
+
+    $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
+    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $this->assertSocialLink($social_label, $social_link, $expected);
+
+    $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
+    $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
+    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
@@ -428,6 +507,98 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Section 1', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom link 1', 'href' => 'http://example.com/custom-link-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Assert updating a general link also changes the footer content.
+    $this->updateGeneralLink('custom-link-1', [
+      'label' => 'Custom link altered',
+      'url' => 'http://example.com/custom-link-altered',
+    ]);
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Section 1', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom link altered', 'href' => 'http://example.com/custom-link-altered'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    // Assert updating a section also changes the footer content.
+    $this->updateSection('section_1', [
+      'label' => 'Section altered',
+      'weight' => -10,
+    ]);
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Section altered', $actual->getText());
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Related sites', $actual->getText());
+
+    // Change component library to ec, assert other links structure.
+    $this->configFactory->getEditable('oe_theme.settings')->set('component_library', 'ec')->save();
+    $this->drupalGet('<front>');
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Contact us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('About us', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
+
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Follow us on', $actual->getText());
+
+    $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
+    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $this->assertSocialLink($social_label, $social_link, $expected);
+
+    $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
+    $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
+    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
+    $this->assertSocialLink($social_label, $social_link, $expected);
+
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+
+    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
+    $this->assertEquals('Section altered', $actual->getText());
+
+    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
+    $expected = ['label' => 'Custom link altered', 'href' => 'http://example.com/custom-link-altered'];
     $this->assertListLink($actual, 'standardised', $expected);
 
     $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
@@ -437,15 +608,6 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
     $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
-    $this->assertListLink($actual, 'standardised', $expected);
-
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
-
-    $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
-    $this->assertEquals('Section 1', $actual->getText());
-
-    $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
-    $expected = ['label' => 'Custom link 1', 'href' => 'http://example.com/custom-link-1'];
     $this->assertListLink($actual, 'standardised', $expected);
   }
 
@@ -573,6 +735,24 @@ class CorporateFooterRenderTest extends BrowserTestBase {
   }
 
   /**
+   * Update a general link given it's id.
+   *
+   * @param string $id
+   *   The link id.
+   * @param array $data
+   *   The link values.
+   */
+  protected function updateGeneralLink(string $id, array $data): void {
+    $link = \Drupal::entityTypeManager()->getStorage('footer_link_general')->load($id);
+
+    foreach ($data as $key => $value) {
+      $link->set($key, $value);
+    }
+
+    $link->save();
+  }
+
+  /**
    * Create a social link given its label and network.
    *
    * @param string $label
@@ -594,17 +774,35 @@ class CorporateFooterRenderTest extends BrowserTestBase {
   /**
    * Create a footer section given its label and id.
    *
-   * @param string $label
-   *   The section label.
    * @param string $id
    *   The section id.
+   * @param string $label
+   *   The section label.
    */
-  protected function createSection(string $label, string $id): void {
+  protected function createSection(string $id, string $label): void {
     $section = \Drupal::entityTypeManager()->getStorage('footer_link_section')->create([
       'id' => $id,
       'label' => $label,
       'weight' => 0,
     ])->save();
+  }
+
+  /**
+   * Update a footer section given its id.
+   *
+   * @param string $id
+   *   The section id.
+   * @param array $data
+   *   The section values.
+   */
+  protected function updateSection(string $id, array $data): void {
+    $section = \Drupal::entityTypeManager()->getStorage('footer_link_section')->load($id);
+
+    foreach ($data as $key => $value) {
+      $section->set($key, $value);
+    }
+
+    $section->save();
   }
 
 }


### PR DESCRIPTION
## EWPP-468

### Description

Add site-specific other links to corporate footers.

### Change log

- Changed:
  - sections 2 and 3 to corporate footer templates
  - adapted the test with new footer link sections and other links


