### PR TITLE
EWPP-441: Create assertion for Text with Featured media pattern.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,9 +103,13 @@
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/3144823": "https://www.drupal.org/files/issues/2020-11-05/3144823-6.patch"
-            },
-            "openeuropa/oe_media": {
-                "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1..master.diff"
+            }
+        },
+        "patches-ignore": {
+            "openeuropa/oe_content": {
+                "openeuropa/oe_media": {
+                    "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
+                }
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "~3.0.0-beta1",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta4",
-        "openeuropa/oe_media": "dev-EWPP-441 as 1.10.1",
+        "openeuropa/oe_media": "^1.10.1",
         "openeuropa/oe_multilingual": "~1.5",
         "openeuropa/oe_paragraphs": "~1.6",
         "openeuropa/oe_search": "~1.0",
@@ -103,13 +103,6 @@
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/3144823": "https://www.drupal.org/files/issues/2020-11-05/3144823-6.patch"
-            }
-        },
-        "patches-ignore": {
-            "openeuropa/oe_content": {
-                "openeuropa/oe_media": {
-                    "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
-                }
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "~3.0.0-beta1",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta4",
-        "openeuropa/oe_media": "^1.10.1",
+        "openeuropa/oe_media": "dev-master as 1.10.1",
         "openeuropa/oe_multilingual": "~1.5",
         "openeuropa/oe_paragraphs": "~1.6",
         "openeuropa/oe_search": "~1.0",
@@ -103,6 +103,13 @@
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/3144823": "https://www.drupal.org/files/issues/2020-11-05/3144823-6.patch"
+            }
+        },
+        "patches-ignore": {
+            "openeuropa/oe_content": {
+                "openeuropa/oe_media": {
+                    "latest-master": "https://github.com/openeuropa/oe_media/compare/1.10.1...master.diff"
+                }
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "openeuropa/oe_content": "dev-master",
         "openeuropa/oe_corporate_blocks": "~3.0.0-beta1",
         "openeuropa/oe_corporate_countries": "~1.0.0-beta4",
-        "openeuropa/oe_media": "^1.10.1",
+        "openeuropa/oe_media": "dev-EWPP-441 as 1.10.1",
         "openeuropa/oe_multilingual": "~1.5",
         "openeuropa/oe_paragraphs": "~1.6",
         "openeuropa/oe_search": "~1.0",

--- a/tests/Functional/ContentCallForTendersRenderTest.php
+++ b/tests/Functional/ContentCallForTendersRenderTest.php
@@ -46,6 +46,7 @@ class ContentCallForTendersRenderTest extends ContentRenderTestBase {
     $media_document = $this->createMediaDocument('call_for_tenders_document');
 
     // Create a Call for tender node.
+    $next_year = date('Y') + 1;
     /** @var \Drupal\node\Entity\Node $node */
     $node = $this->getStorage('node')->create([
       'type' => 'oe_call_tenders',
@@ -64,7 +65,7 @@ class ContentCallForTendersRenderTest extends ContentRenderTestBase {
         'value' => '2020-04-30',
       ],
       'oe_call_tenders_deadline' => [
-        'value' => date('Y') + 1 . '-06-10T23:30:00',
+        'value' => $next_year . '-06-10T23:30:00',
       ],
       'oe_reference_code' => 'Call for tenders reference',
       'oe_departments' => 'http://publications.europa.eu/resource/authority/corporate-body/ABEC',
@@ -134,7 +135,7 @@ class ContentCallForTendersRenderTest extends ContentRenderTestBase {
       'Call for tenders reference',
       '15 April 2020',
       '30 April 2020',
-      '11 June 2021, 09:30 (AEST)',
+      "11 June $next_year, 09:30 (AEST)",
       'Audit Board of the European Communities',
     ];
     foreach ($values_data as $index => $value) {
@@ -163,12 +164,12 @@ class ContentCallForTendersRenderTest extends ContentRenderTestBase {
     $this->assertEquals('Audit Board of the European Communities | Associated African States and Madagascar', $values[5]->getText());
 
     // Assert status "Upcoming".
-    $node->set('oe_call_tenders_opening_date', ['value' => date('Y') + 1 . '-05-31']);
+    $node->set('oe_call_tenders_opening_date', ['value' => $next_year . '-05-31']);
     $node->save();
     $this->drupalGet($node->toUrl());
     $this->assertStatusValue($content, 'Upcoming');
-    $this->assertOpeningDateValue($content, '31 May 2021');
-    $this->assertDeadlineDateValue($content, '11 June 2021, 09:30 (AEST)');
+    $this->assertOpeningDateValue($content, "31 May $next_year");
+    $this->assertDeadlineDateValue($content, "11 June $next_year, 09:30 (AEST)");
     $this->assertSession()->elementTextContains('css', '.ecl-page-header-core .ecl-page-header-core__meta', 'Call for tenders | Upcoming');
 
     // Assert status "Closed".

--- a/tests/PatternAssertions/BasePatternAssert.php
+++ b/tests/PatternAssertions/BasePatternAssert.php
@@ -115,7 +115,7 @@ abstract class BasePatternAssert extends Assert implements PatternAssertInterfac
     $element = $crawler->filter($selector);
     $actual = trim($element->text());
     self::assertEquals($expected, $actual, \sprintf(
-      'Expected value "%s" is not equal actual value "%s" in the selector "%s".',
+      'Expected text value "%s" is not equal to the actual value "%s" found in the selector "%s".',
       $expected, $actual, $selector
     ));
   }

--- a/tests/PatternAssertions/BasePatternAssert.php
+++ b/tests/PatternAssertions/BasePatternAssert.php
@@ -187,8 +187,10 @@ abstract class BasePatternAssert extends Assert implements PatternAssertInterfac
       $this->assertElementNotExists($selector, $crawler);
       return;
     }
-    $this->assertElementAttribute($expected_image['src'], $selector, 'src', $crawler);
-    $this->assertElementAttribute($expected_image['alt'], $selector, 'alt', $crawler);
+    $this->assertElementExists($selector, $crawler);
+    $element = $crawler->filter($selector);
+    self::assertEquals($expected_image['alt'], $element->attr('alt'));
+    self::assertContains($expected_image['src'], $element->attr('src'));
   }
 
 }

--- a/tests/PatternAssertions/BasePatternAssert.php
+++ b/tests/PatternAssertions/BasePatternAssert.php
@@ -113,7 +113,11 @@ abstract class BasePatternAssert extends Assert implements PatternAssertInterfac
     }
     $this->assertElementExists($selector, $crawler);
     $element = $crawler->filter($selector);
-    self::assertEquals($expected, trim($element->text()));
+    $actual = trim($element->text());
+    self::assertEquals($expected, $actual, \sprintf(
+      'Expected value "%s" is not equal actual value "%s" in the selector "%s".',
+      $expected, $actual, $selector
+    ));
   }
 
   /**
@@ -166,6 +170,25 @@ abstract class BasePatternAssert extends Assert implements PatternAssertInterfac
       'Element with selector "%s" was found in the provided html.',
       $selector
     ));
+  }
+
+  /**
+   * Asserts the image of the pattern.
+   *
+   * @param array|null $expected_image
+   *   The expected image.
+   * @param string $selector
+   *   The CSS selector to find the element.
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   The DomCrawler where to check the element.
+   */
+  protected function assertImage(?array $expected_image, string $selector, Crawler $crawler): void {
+    if (is_null($expected_image)) {
+      $this->assertElementNotExists($selector, $crawler);
+      return;
+    }
+    $this->assertElementAttribute($expected_image['src'], $selector, 'src', $crawler);
+    $this->assertElementAttribute($expected_image['alt'], $selector, 'alt', $crawler);
   }
 
 }

--- a/tests/PatternAssertions/FeaturedItemAssert.php
+++ b/tests/PatternAssertions/FeaturedItemAssert.php
@@ -29,7 +29,7 @@ class FeaturedItemAssert extends BasePatternAssert {
         $variant == 'extended' ? 'article.ecl-card div.ecl-card__body div.ecl-card__description p.ecl-paragraph' : 'article.ecl-card div.ecl-card__body div.ecl-card__description',
       ],
       'image' => [
-        [$this, 'assertImage'],
+        [$this, 'assertFeaturedItemImage'],
         $variant,
       ],
       'meta' => [
@@ -60,7 +60,7 @@ class FeaturedItemAssert extends BasePatternAssert {
    * @param \Symfony\Component\DomCrawler\Crawler $crawler
    *   The DomCrawler where to check the element.
    */
-  protected function assertImage($expected_image, Crawler $crawler): void {
+  protected function assertFeaturedItemImage($expected_image, Crawler $crawler): void {
     $image_div = $crawler->filter('article.ecl-card header.ecl-card__header div.ecl-card__image');
     self::assertEquals($expected_image['alt'], $image_div->attr('aria-label'));
     self::assertContains($expected_image['src'], $image_div->attr('style'));

--- a/tests/PatternAssertions/FileTeaserAssert.php
+++ b/tests/PatternAssertions/FileTeaserAssert.php
@@ -18,6 +18,7 @@ class FileTeaserAssert extends FileTranslationAssert {
     $assertions = parent::getAssertions($variant);
     $assertions['thumbnail'] = [
       [$this, 'assertImage'],
+      'div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail img.ecl-file__image',
     ];
     $assertions['teaser'] = [
       [$this, 'assertElementText'],
@@ -27,23 +28,6 @@ class FileTeaserAssert extends FileTranslationAssert {
       [$this, 'assertMeta'],
     ];
     return $assertions;
-  }
-
-  /**
-   * Asserts the image of the pattern.
-   *
-   * @param array|null $expected_image
-   *   The expected image.
-   * @param \Symfony\Component\DomCrawler\Crawler $crawler
-   *   The DomCrawler where to check the element.
-   */
-  protected function assertImage($expected_image, Crawler $crawler): void {
-    if (is_null($expected_image)) {
-      $this->assertElementNotExists('div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail div.ecl-file__image img', $crawler);
-      return;
-    }
-    $this->assertElementAttribute($expected_image['src'], 'div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail img.ecl-file__image', 'src', $crawler);
-    $this->assertElementAttribute($expected_image['alt'], 'div.ecl-file--thumbnail div.ecl-file__container div.ecl-file__detail img.ecl-file__image', 'alt', $crawler);
   }
 
   /**

--- a/tests/PatternAssertions/TextFeaturedMediaAssert.php
+++ b/tests/PatternAssertions/TextFeaturedMediaAssert.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\oe_theme\PatternAssertions;
+
+use Symfony\Component\DomCrawler\Crawler;
+use PHPUnit\Framework\Exception;
+
+/**
+ * Assertions for text_featured_media pattern.
+ *
+ *  @see ./templates/patterns/text_featured_media/text_featured_media.ui_patterns.yml
+ */
+class TextFeaturedMediaAssert extends BasePatternAssert {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getAssertions($variant): array {
+    return [
+      'title' => [
+        [$this, 'assertElementText'],
+        'h2.ecl-u-type-heading-2.ecl-u-mt-2xl.ecl-u-mt-md-3xl.ecl-u-mb-l',
+      ],
+      'image' => [
+        [$this, 'assertImage'],
+        'div.ecl-row figure.ecl-media-container img',
+      ],
+      'video' => [
+        [$this, 'assertElementHtml'],
+        'div.ecl-row figure.ecl-media-container div.ecl-media-container__media',
+      ],
+      'caption' => [
+        [$this, 'assertElementText'],
+        'div.ecl-row figure figcaption.ecl-media-container__caption',
+      ],
+      'text' => [
+        [$this, 'assertElementText'],
+        'div.ecl-row div.ecl-col-md-6.ecl-editor',
+      ],
+      'video_ratio' => [
+        [$this, 'assertVideoRatio'],
+        'div.ecl-row figure.ecl-media-container div.ecl-media-container__media',
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function assertBaseElements(string $html, string $variant): void {}
+
+  /**
+   * Asserts the video ratio of the pattern.
+   *
+   * @param string $expected_ratio
+   *   The expected class with the video ratio.
+   * @param string $selector
+   *   The CSS selector to find the element.
+   * @param \Symfony\Component\DomCrawler\Crawler $crawler
+   *   The DomCrawler where to check the element.
+   */
+  protected function assertVideoRatio(string $expected_ratio, string $selector, Crawler $crawler): void {
+    self::assertElementExists($selector, $crawler);
+
+    $element = $crawler->filter($selector);
+    $existing_classes = $element->attr('class');
+    $existing_classes = explode(' ', $existing_classes);
+
+    $expected_ratio = str_replace(':', '-', $expected_ratio);
+    if (!in_array('ecl-media-container__media--ratio-' . $expected_ratio, $existing_classes)) {
+      throw new Exception(sprintf('Element with selector %s does not use ratio %s.', $selector, $expected_ratio));
+    }
+  }
+
+}

--- a/tests/PatternAssertions/TextFeaturedMediaAssert.php
+++ b/tests/PatternAssertions/TextFeaturedMediaAssert.php
@@ -55,7 +55,7 @@ class TextFeaturedMediaAssert extends BasePatternAssert {
    * Asserts the video ratio of the pattern.
    *
    * @param string $expected_ratio
-   *   The expected class with the video ratio.
+   *   The video ratio.
    * @param string $selector
    *   The CSS selector to find the element.
    * @param \Symfony\Component\DomCrawler\Crawler $crawler
@@ -70,7 +70,7 @@ class TextFeaturedMediaAssert extends BasePatternAssert {
 
     $expected_ratio = str_replace(':', '-', $expected_ratio);
     if (!in_array('ecl-media-container__media--ratio-' . $expected_ratio, $existing_classes)) {
-      throw new Exception(sprintf('Element with selector %s does not use ratio %s.', $selector, $expected_ratio));
+      throw new Exception(sprintf('The element with the selector %s does not use the ratio %s.', $selector, $expected_ratio));
     }
   }
 

--- a/tests/PatternAssertions/TextFeaturedMediaAssert.php
+++ b/tests/PatternAssertions/TextFeaturedMediaAssert.php
@@ -37,7 +37,7 @@ class TextFeaturedMediaAssert extends BasePatternAssert {
       ],
       'text' => [
         [$this, 'assertElementText'],
-        'div.ecl-row div.ecl-col-md-6.ecl-editor',
+        'div.ecl-row > div.ecl-editor',
       ],
       'video_ratio' => [
         [$this, 'assertVideoRatio'],


### PR DESCRIPTION
## EWPP-441

### Description

Create assertion for text_featured_media pattern

### Change log

- Added: TextFeaturedMediaAssert.php
- Changed: assertImage() has been moved to BasePatternAssert

### Examples of usage

```php
$assert = new TextFeaturedMediaAssert();
$expected_values = [
  'title' => 'Description',
  'caption' => 'Caption1',
  'text' => 'Body',
  'video' => '<iframe src="https://www.youtube.com/embed/..." frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>',
  'video_ratio' => '1:1',
];
$assert->assertPattern($expected_values, $html);
```

```php
$assert = new TextFeaturedMediaAssert();
$expected_values = [
  'title' => 'Lorem ipsum',
  'caption' => 'Event featured media legend',
  'text' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Non enim iam stirpis bonum quaeret, sed animalis.',
  'image' => [
    'alt' => 'Alternative text event_featured_media',
    'src' => example.png',
  ],
];
$assert->assertPattern($expected_values, $html);
```