### PR TITLE
EWPP-631: Fix double encoding of html entities.

### DIFF
--- a/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
+++ b/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme_content_event\Plugin\ExtraField\Display;
 
+use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
@@ -181,10 +182,10 @@ class DetailsExtraField extends EventExtraFieldBase implements ContainerFactoryP
 
     // Only display locality and country, inline.
     $renderable = $this->entityTypeManager->getViewBuilder('oe_venue')->viewField($venue->get('oe_address'));
-
     $build['#fields']['items'][] = [
       'icon' => 'location',
-      'text' => $renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value'],
+      // We receive double encoded strings so we need to decode.
+      'text' => Html::decodeEntities($renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value']),
     ];
   }
 

--- a/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
+++ b/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\oe_theme_content_event\Plugin\ExtraField\Display;
 
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Cache\CacheableMetadata;
 use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\Core\Entity\EntityRepositoryInterface;
@@ -184,8 +183,11 @@ class DetailsExtraField extends EventExtraFieldBase implements ContainerFactoryP
     $renderable = $this->entityTypeManager->getViewBuilder('oe_venue')->viewField($venue->get('oe_address'));
     $build['#fields']['items'][] = [
       'icon' => 'location',
-      // We receive double encoded strings so we need to decode.
-      'text' => Html::decodeEntities($renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value']),
+      'text' => [
+        '#type' => 'html_tag',
+        '#tag' => 'span',
+        '#value' => $renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value'],
+      ],
     ];
   }
 

--- a/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
+++ b/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/DetailsExtraField.php
@@ -184,9 +184,7 @@ class DetailsExtraField extends EventExtraFieldBase implements ContainerFactoryP
     $build['#fields']['items'][] = [
       'icon' => 'location',
       'text' => [
-        '#type' => 'html_tag',
-        '#tag' => 'span',
-        '#value' => $renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value'],
+        '#markup' => $renderable[0]['locality']['#value'] . ', ' . $renderable[0]['country']['#value'],
       ],
     ];
   }

--- a/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
+++ b/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
@@ -91,7 +91,6 @@ class AddressInlineFormatter extends AddressDefaultFormatter {
 
     $address_elements['%country'] = $countries[$country_code];
     foreach ($address_format->getUsedFields() as $field) {
-      drupal_set_message($field);
       $address_elements['%' . $field] = $values[$field];
     }
 

--- a/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
+++ b/modules/oe_theme_helper/src/Plugin/Field/FieldFormatter/AddressInlineFormatter.php
@@ -7,7 +7,6 @@ namespace Drupal\oe_theme_helper\Plugin\Field\FieldFormatter;
 use CommerceGuys\Addressing\Locale;
 use Drupal\address\AddressInterface;
 use Drupal\address\Plugin\Field\FieldFormatter\AddressDefaultFormatter;
-use Drupal\Component\Utility\Html;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
@@ -90,9 +89,10 @@ class AddressInlineFormatter extends AddressDefaultFormatter {
     $address_format = $this->addressFormatRepository->get($country_code);
     $values = $this->getValues($address, $address_format);
 
-    $address_elements['%country'] = Html::escape($countries[$country_code]);
+    $address_elements['%country'] = $countries[$country_code];
     foreach ($address_format->getUsedFields() as $field) {
-      $address_elements['%' . $field] = Html::escape($values[$field]);
+      drupal_set_message($field);
+      $address_elements['%' . $field] = $values[$field];
     }
 
     if (Locale::matchCandidates($address_format->getLocale(), $address->getLocale())) {
@@ -118,7 +118,7 @@ class AddressInlineFormatter extends AddressDefaultFormatter {
   }
 
   /**
-   * Extract address items from a format string and replaces placeholders.
+   * Extract address items from a format string and replace placeholders.
    *
    * @param string $string
    *   The address format string, containing placeholders.

--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
@@ -37,10 +37,11 @@ class AddressInlineFormatterTest extends FormatterTestBase {
       'locality' => 'Brussels',
       'postal_code' => '1000',
       'address_line1' => 'Rue de la Loi, 56 <123>',
+      'address_line2' => 'or \'Wetstraat\' (Dutch), meaning "Law Street"',
     ];
 
     $this->renderEntityFields($entity, $this->display);
-    $expected = 'Rue de la Loi, 56 &lt;123&gt;, 1000 Brussels, Belgium';
+    $expected = 'Rue de la Loi, 56 &lt;123&gt;, or &#039;Wetstraat&#039; (Dutch), meaning &quot;Law Street&quot;, 1000 Brussels, Belgium';
     $this->assertRaw($expected);
   }
 

--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
@@ -34,14 +34,14 @@ class AddressInlineFormatterTest extends FormatterTestBase {
     $entity = EntityTestMul::create([]);
     $entity->{$this->fieldName} = [
       'country_code' => 'BE',
-      'locality' => 'Brussels',
+      'locality' => 'Brussels <Bruxelles>',
       'postal_code' => '1000',
       'address_line1' => 'Rue de la Loi, 56 <123>',
       'address_line2' => 'or \'Wetstraat\' (Dutch), meaning "Law Street"',
     ];
 
     $this->renderEntityFields($entity, $this->display);
-    $expected = 'Rue de la Loi, 56 &lt;123&gt;, or &#039;Wetstraat&#039; (Dutch), meaning &quot;Law Street&quot;, 1000 Brussels, Belgium';
+    $expected = 'Rue de la Loi, 56 &lt;123&gt;, or &#039;Wetstraat&#039; (Dutch), meaning &quot;Law Street&quot;, 1000 Brussels &lt;Bruxelles&gt;, Belgium';
     $this->assertRaw($expected);
   }
 

--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/AddressInlineFormatterTest.php
@@ -36,11 +36,11 @@ class AddressInlineFormatterTest extends FormatterTestBase {
       'country_code' => 'BE',
       'locality' => 'Brussels',
       'postal_code' => '1000',
-      'address_line1' => 'Rue de la Loi, 56',
+      'address_line1' => 'Rue de la Loi, 56 <123>',
     ];
 
     $this->renderEntityFields($entity, $this->display);
-    $expected = 'Rue de la Loi, 56, 1000 Brussels, Belgium';
+    $expected = 'Rue de la Loi, 56 &lt;123&gt;, 1000 Brussels, Belgium';
     $this->assertRaw($expected);
   }
 


### PR DESCRIPTION
## EWPP-631

### Description

Fix double encoding of html entities.

### Change log

- Changed: AddressInlineFormatter
- Fixed: Fix double encoding of html entities.


