### PR TITLE
EWPP-632: Link list card container breaks if content is too long.

### DIFF
--- a/sass/components/_card.scss
+++ b/sass/components/_card.scss
@@ -1,0 +1,3 @@
+.ecl-card {
+  overflow-wrap: break-word;
+}

--- a/sass/style-ec.scss
+++ b/sass/style-ec.scss
@@ -15,3 +15,4 @@
 @import "./components/global";
 @import "./components/description_list";
 @import "./components/media_iframe";
+@import "./components/card";


### PR DESCRIPTION
## EWPP-632
### Description

Fixes the overflow text in the link list cards

### Change log

- Added: CSS statement 

