### PR TITLE
EWPP-1031: Fix tests that use role reference field.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "openeuropa/behat-transformation-context": "~0.1",
         "openeuropa/code-review": "~1.5",
         "openeuropa/drupal-core-require-dev": "^8.9.13",
-        "openeuropa/oe_content": "~2.1",
+        "openeuropa/oe_content": "dev-release-2.1.x",
         "openeuropa/oe_corporate_blocks": "~4.0",
         "openeuropa/oe_corporate_countries": "~2.0",
         "openeuropa/oe_media": "~1.11",

--- a/tests/Functional/ContentPersonRenderTest.php
+++ b/tests/Functional/ContentPersonRenderTest.php
@@ -203,12 +203,12 @@ class ContentPersonRenderTest extends ContentRenderTestBase {
     // Assert Jobs field.
     $job_1 = $this->createPersonJobEntity('job_1', [
       'oe_acting' => TRUE,
-      'oe_role_reference' => 'http://publications.europa.eu/resource/authority/role/MEMBER',
+      'oe_role_reference' => 'http://publications.europa.eu/resource/authority/role-qualifier/ADVIS',
     ]);
     $node->set('oe_person_jobs', $job_1)->save();
     $this->drupalGet($node->toUrl());
 
-    $page_header_expected_values['meta'] = '(Acting) Member';
+    $page_header_expected_values['meta'] = '(Acting) Advisor';
     $assert->assertPattern($page_header_expected_values, $page_header->getOuterHtml());
 
     $inpage_nav_expected_values['list'][] = [
@@ -221,21 +221,21 @@ class ContentPersonRenderTest extends ContentRenderTestBase {
     $this->assertCount(3, $content_items);
     $this->assertContentHeader($content_items[2], 'Responsibilities', 'responsibilities');
     $job_role_content = $content_items[2]->find('css', 'h3.ecl-u-type-heading-3.ecl-u-mt-none.ecl-u-mb-s');
-    $this->assertEquals('(Acting) Member', $job_role_content->getText());
+    $this->assertEquals('(Acting) Advisor', $job_role_content->getText());
     $job_description_content = $content_items[2]->find('css', 'div.ecl-u-mb-l.ecl-editor');
     $this->assertEquals('Description job_1', $job_description_content->getText());
 
     // Assert Jobs field with multiple values.
-    $job_2 = $this->createPersonJobEntity('job_2', ['oe_role_reference' => 'http://publications.europa.eu/resource/authority/role/ADVOC']);
+    $job_2 = $this->createPersonJobEntity('job_2', ['oe_role_reference' => 'http://publications.europa.eu/resource/authority/role-qualifier/ADVIS_CHIEF']);
     $node->set('oe_person_jobs', [$job_1, $job_2])->save();
     $this->drupalGet($node->toUrl());
 
-    $page_header_expected_values['meta'] = '(Acting) Member, Advocate';
+    $page_header_expected_values['meta'] = '(Acting) Advisor, Chief advisor';
     $assert->assertPattern($page_header_expected_values, $page_header->getOuterHtml());
 
     $content_items = $content->findAll('xpath', '/div');
     $job_role_items = $content_items[2]->findAll('css', 'h3.ecl-u-type-heading-3.ecl-u-mt-none.ecl-u-mb-s');
-    $this->assertEquals('Advocate', $job_role_items[1]->getText());
+    $this->assertEquals('Chief advisor', $job_role_items[1]->getText());
     $job_description_items = $content_items[2]->findAll('css', 'div.ecl-u-mb-l.ecl-editor');
     $this->assertEquals('Description job_2', $job_description_items[1]->getText());
 

--- a/tests/Kernel/PersonRenderTest.php
+++ b/tests/Kernel/PersonRenderTest.php
@@ -240,31 +240,31 @@ class PersonRenderTest extends ContentRenderTestBase {
     // Assert Jobs field.
     $job_1 = $this->createPersonJobEntity('job_1', [
       'oe_acting' => TRUE,
-      'oe_role_reference' => 'http://publications.europa.eu/resource/authority/role/MEMBER',
+      'oe_role_reference' => 'http://publications.europa.eu/resource/authority/role-qualifier/ADVIS',
     ]);
     $node->set('oe_person_contacts', NULL);
     $node->set('oe_person_jobs', $job_1)->save();
-    $expected_values['meta'] = '(Acting) Member';
+    $expected_values['meta'] = '(Acting) Advisor';
     $expected_values['additional_information'][1] = new PatternAssertState(new FieldListAssert(), [
       'items' => [
         [
-          'label' => '(Acting) Member',
+          'label' => '(Acting) Advisor',
           'body' => 'Description job_1',
         ],
       ],
     ]);
     $assert->assertPattern($expected_values, $this->getRenderedNode($node));
 
-    $job_2 = $this->createPersonJobEntity('job_2', ['oe_role_reference' => 'http://publications.europa.eu/resource/authority/role/ADVOC']);
+    $job_2 = $this->createPersonJobEntity('job_2', ['oe_role_reference' => 'http://publications.europa.eu/resource/authority/role-qualifier/ADVIS_CHIEF']);
     $node->set('oe_person_jobs', [$job_1, $job_2])->save();
-    $expected_values['meta'] = '(Acting) Member, Advocate';
+    $expected_values['meta'] = '(Acting) Advisor, Chief advisor';
     $expected_values['additional_information'][1] = new PatternAssertState(new FieldListAssert(), [
       'items' => [
         [
-          'label' => '(Acting) Member',
+          'label' => '(Acting) Advisor',
           'body' => 'Description job_1',
         ], [
-          'label' => 'Advocate',
+          'label' => 'Chief advisor',
           'body' => 'Description job_2',
         ],
       ],


### PR DESCRIPTION
## EWPP-1031
### Description

Fix tests that use role reference field.
### Change log

- Added:
- Changed:Fix tests that use role reference field.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

