### PR TITLE
EWPP-1147: Update footer templates to use ECL V3.

### DIFF
--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -679,7 +679,7 @@ class TwigExtension extends \Twig_Extension {
         $ecl_link += [
           'icon' => [
             'path' => $context['ecl_icon_social_media_path'],
-            'name' => $link['social_network'],
+            'name' => $context['ecl_component_library'] == 'eu' ? $link['social_network'] : $link['social_network'] . '-negative',
           ],
         ];
       }

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -678,7 +678,7 @@ class TwigExtension extends \Twig_Extension {
         $ecl_link['link']['icon_position'] = 'before';
         $ecl_link += [
           'icon' => [
-            'path' => $context['ecl_social_icon_path'],
+            'path' => $context['ecl_icon_social_media_path'],
             'name' => $link['social_network'],
           ],
         ];

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -678,7 +678,7 @@ class TwigExtension extends \Twig_Extension {
         $ecl_link['link']['icon_position'] = 'before';
         $ecl_link += [
           'icon' => [
-            'path' => $context['ecl_icon_path'],
+            'path' => $context['ecl_social_icon_path'],
             'name' => $link['social_network'],
           ],
         ];

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -670,6 +670,7 @@ class TwigExtension extends \Twig_Extension {
           'icon' => [
             'path' => $context['ecl_icon_path'],
             'name' => 'external',
+            'size' => 'xs',
           ],
         ];
       }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -73,7 +73,7 @@ function oe_theme_preprocess(&$variables) {
   $variables['ecl_images_path'] = base_path() . drupal_get_path('theme', 'oe_theme') . '/dist/' . $variables['ecl_component_library'] . '/images';
   $variables['ecl_icon_path'] = $variables['ecl_images_path'] . '/icons/sprites/icons.svg';
   $variables['ecl_logo_path'] = $variables['ecl_images_path'] . '/logo';
-  $variables['ecl_social_icon_path'] = $variables['ecl_images_path'] . '/social-icons/sprites/icons-social.svg';
+  $variables['ecl_social_icon_path'] = $variables['ecl_images_path'] . '/icons-social-media/sprites/icons-social-media.svg';
   $variables['current_language_id'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
 }
 

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -73,7 +73,8 @@ function oe_theme_preprocess(&$variables) {
   $variables['ecl_images_path'] = base_path() . drupal_get_path('theme', 'oe_theme') . '/dist/' . $variables['ecl_component_library'] . '/images';
   $variables['ecl_icon_path'] = $variables['ecl_images_path'] . '/icons/sprites/icons.svg';
   $variables['ecl_logo_path'] = $variables['ecl_images_path'] . '/logo';
-  $variables['ecl_social_icon_path'] = $variables['ecl_images_path'] . '/icons-social-media/sprites/icons-social-media.svg';
+  $variables['ecl_social_icon_path'] = base_path() . drupal_get_path('theme', 'oe_theme') . '/dist/ec/images/social-icons/sprites/icons-social.svg';
+  $variables['ecl_icon_social_media_path'] = $variables['ecl_images_path'] . '/icons-social-media/sprites/icons-social-media.svg';
   $variables['current_language_id'] = \Drupal::languageManager()->getCurrentLanguage()->getId();
 }
 

--- a/sass/components/_global.scss
+++ b/sass/components/_global.scss
@@ -4,6 +4,8 @@
 
 body {
   font-family: map.get(theme.$font-family, 'default');
+  margin: 0;
+  padding: 0;
 }
 
 a {

--- a/templates/navigation/oe-corporate-blocks-ec-footer--core.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--core.html.twig
@@ -11,30 +11,35 @@
  */
 #}
 
-{% set _sections = [
-  {
-    'title': {
-      'link': {
-        'label': corporate_footer.corporate_site_link.label,
-        'path': corporate_footer.corporate_site_link.href,
+{% set _row = [
+  [
+    {
+      'title': {
+        'link': {
+          'label': corporate_footer.corporate_site_link.label,
+          'path': corporate_footer.corporate_site_link.href,
+        },
       },
+      'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
     },
-    'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
-  },
-  {
-    'content_before': 'More information on:'|t,
-    'links': ecl_footer_links(corporate_footer.class_navigation),
-    'list_class_name': 'ecl-footer-core__section2 ecl-footer-core__list--columns',
-    'section_class_name': 'ecl-footer-core__section--separator',
-  },
-  {
-    'links': ecl_footer_links(corporate_footer.service_navigation),
-  },
-  {
-    'links': ecl_footer_links(corporate_footer.legal_navigation),
-  },
-] %}
+  ],
+  [
+    {
+      'content_before': 'More information on:'|t,
+      'links': ecl_footer_links(corporate_footer.class_navigation),
+      'links_columns': true,
+      'section_with_separator': true,
+    },
+    {
+      'links': ecl_footer_links(corporate_footer.service_navigation),
+    },
+    {
+      'links': ecl_footer_links(corporate_footer.legal_navigation),
+    },
+  ]
+]
+ %}
 
 {% include '@ecl-twig/footer-core' with {
-  'sections': _sections,
+  'rows': [_row],
 } %}

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -11,24 +11,22 @@
  */
 #}
 
-{% set _section_2 = [] %}
-{% set _section_3 = [] %}
+{% set _top_left_column = [] %}
+{% set _top_right_column = [] %}
 
 {# First we parse the other_links, we make a simple grid. #}
 {% for section in site_specific_footer.other_links %}
   {% if loop.index is odd %}
-    {% set _section_2 = _section_2|merge([{
+    {% set _top_left_column = _top_left_column|merge([{
       'title': section.label,
+      'title_with_separator': true,
       'links': ecl_footer_links(section.links),
-      'section_id': 2,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
     }]) %}
   {% else %}
-    {% set _section_3 = _section_3|merge([{
+    {% set _top_right_column = _top_right_column|merge([{
       'title': section.label,
+      'title_with_separator': true,
       'links': ecl_footer_links(section.links),
-      'section_id': 3,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
     }]) %}
   {% endif %}
 {% endfor %}
@@ -36,84 +34,71 @@
 {# When follow section is present. #}
 {% if site_specific_footer.social_links is not empty %}
   {# If section numbers are odd, then we flip the last row so to have the follow as first. #}
-  {% if _section_2|length > _section_3|length %}
-    {% set _last_in_section_2 = _section_2|last %}
+  {% if _top_left_column|length > _top_right_column|length %}
+    {% set _last_in_top_left_column = _top_left_column|last %}
 
-    {# Compensate for bug in twig where _section_2[1:] returns empty if _section_2|length is 1. #}
-    {% if _last_in_section_2 is empty %}
-      {% set _last_in_section_2 = _section_2[0] %}
-      {% set _section_2 = [] %}
+    {# Compensate for bug in twig where _top_left_column[1:] returns empty if _top_left_column|length is 1. #}
+    {% if _last_in_top_left_column is empty %}
+      {% set _last_in_top_left_column = _top_left_column[0] %}
+      {% set _top_left_column = [] %}
     {% endif %}
 
-    {% set _section_2 = _section_2[:_section_2|length - 1] %}
-    {% set _last_in_section_2 = _last_in_section_2|merge({'section_id': 3}) %}
-    {% set _section_3 = _section_3|merge([_last_in_section_2]) %}
+    {% set _top_left_column = _top_left_column[:_top_left_column|length - 1] %}
+    {% set _top_right_column = _top_right_column|merge([_last_in_top_left_column]) %}
 
   {% endif %}
 
   {# Follow section must always be the last on the left. #}
-  {% set _section_2 = _section_2|merge([{
+  {% set _top_left_column = _top_left_column|merge([{
     'title': 'Follow us'|t,
+    'title_with_separator': true,
     'links': ecl_footer_links(site_specific_footer.social_links),
-    'section_id': 2,
-    'list_class_name': 'ecl-footer-standardised__list--inline',
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }]) %}
-{% endif %}
-
-{# Section 2 and 3 needs minimum 2 items to display. #}
-{% if _section_2|length == 1 %}
-  {% set _section_2 = _section_2|merge([{
-    'section_id': 2,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
-  }]) %}
-{% endif %}
-
-{% if _section_3|length == 1 %}
-  {% set _section_3 = _section_3|merge([{
-    'section_id': 3,
-    'title_class_name': 'ecl-footer-standardised__title--separator',
+    'links_inline': true,
   }]) %}
 {% endif %}
 
 {% block content %}
-  {% set _sections = [
-    {
-      'title': {
-      'link': {
-        'label': site_specific_footer.site_identity,
-        'path': url('<front>'),
-      }
-    },
-      'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
-      'section_id': 1,
-    },
-    _section_2,
-    _section_3,
-    {
-      'section_id': 6,
-      'list_class_name': 'ecl-footer-standardised__list--condensed',
-    },
-    {
-      'title': {
-      'link': {
-        'label': corporate_footer.corporate_site_link.label,
-        'path': corporate_footer.corporate_site_link.href,
+  {# Populate the top row with the site identity and the custom links. #}
+  {% set _top_row = [
+    [
+      {
+        'title': {
+        'link': {
+          'label': site_specific_footer.site_identity,
+          'path': url('<front>'),
+        }
       },
-    },
-      'section_id': 7,
-    },
-    {
-      'links': ecl_footer_links(corporate_footer.service_navigation),
-      'section_id': 8,
-    },
-    {
-      'links': ecl_footer_links(corporate_footer.legal_navigation),
-      'section_id': 9,
-    },
+        'description': site_owner ? 'This site is managed by the @name'|t({'@name': site_owner}),
+      }
+    ],
+    _top_left_column,
+    _top_right_column
   ] %}
 
+  {# Populate the bottom row with the corporate links. #}
+  {% set _bottom_row = [
+    [
+      {
+        'title': {
+        'link': {
+          'label': corporate_footer.corporate_site_link.label,
+          'path': corporate_footer.corporate_site_link.href,
+        },
+      },
+      }
+    ],
+    [
+      {
+        'links': ecl_footer_links(corporate_footer.service_navigation),
+      }
+    ],
+    [
+      {
+        'links': ecl_footer_links(corporate_footer.legal_navigation),
+      }
+    ],
+  ] %}
   {% include '@ecl-twig/footer-standardised' with {
-    'sections': _sections,
+    'rows': [ _top_row, _bottom_row],
   } %}
 {% endblock %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
@@ -11,16 +11,14 @@
  */
 #}
 
-{% set _logo_path = ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
-
 {% set _row = [
   [
     {
       'logo': {
         'path': 'https://europa.eu/',
         'language': current_language_id,
-        'src_mobile': _logo_path,
-        'src_desktop': _logo_path,
+        'src_mobile': ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg',
+        'src_desktop': ecl_logo_path ~ '/standard-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg',
       },
       'description': site_owner ? 'This site is managed by the European Commission, @name'|t({'@name': site_owner}),
     },

--- a/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
@@ -11,38 +11,46 @@
  */
 #}
 
-{% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
+{% set _logo_path = ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
 
-{% set _sections = [
-  {
-    'logo': {
-      'path': 'https://europa.eu/',
-      'language': current_language_id,
-      'src_mobile': _logo_path,
-      'src_desktop': _logo_path,
+{% set _row = [
+  [
+    {
+      'logo': {
+        'path': 'https://europa.eu/',
+        'language': current_language_id,
+        'src_mobile': _logo_path,
+        'src_desktop': _logo_path,
+      },
+      'description': site_owner ? 'This site is managed by the European Commission, @name'|t({'@name': site_owner}),
     },
-    'description': site_owner ? 'This site is managed by the European Commission, @name'|t({'@name': site_owner}),
-  },
+  ],
   [
     {
       'title': corporate_footer.contact_title,
+      'title_with_separator': true,
       'links': ecl_footer_links(corporate_footer.contact),
     },
     {
       'title': corporate_footer.social_media_title,
+      'title_with_separator': true,
       'links': ecl_footer_links(corporate_footer.social_media),
     },
     {
       'title': corporate_footer.legal_links_title,
+      'title_with_separator': true,
       'links': ecl_footer_links(corporate_footer.legal_links),
     },
   ],
-  {
-    'title': corporate_footer.institution_links_title,
-    'links': ecl_footer_links(corporate_footer.institution_links),
-  },
+  [
+    {
+      'title': corporate_footer.institution_links_title,
+      'title_with_separator': true,
+      'links': ecl_footer_links(corporate_footer.institution_links),
+    },
+  ],
 ] %}
 
 {% include '@ecl-twig/footer-core' with {
-  'sections': _sections,
+  'rows': [_row],
 } %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -14,62 +14,63 @@
 {% extends "@oe_theme/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig" %}
 
 {% block content %}
-  {% set _logo_path = ecl_logo_path ~ '/logo--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
-  {% set _sections = [
-    {
-      'title': {
-      'link': {
-        'label': site_specific_footer.site_identity,
-        'path': url('<front>'),
+  {% set _logo_path = ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
+  {# Populate the top row with the site identity and the custom links. #}
+  {% set _top_row = [
+    [
+      {
+        'title': {
+        'link': {
+          'label': site_specific_footer.site_identity,
+          'path': url('<front>'),
+        }
+      },
+        'description': site_owner ? 'This site is managed by the European Commission, @name'|t({'@name': site_owner}),
       }
-    },
-      'description': site_owner ? 'This site is managed by the European Commission, @name'|t({'@name': site_owner}),
-      'section_id': 1,
-    },
-    _section_2,
-    _section_3,
-    {
-      'section_id': 6,
-    },
-    {
-      'logo': {
-      'path': 'https://europa.eu/',
-      'language': current_language_id,
-      'src_mobile': _logo_path,
-      'src_desktop': _logo_path,
-    },
-      'description': logo_description,
-      'section_id': 7,
-    },
+    ],
+    _top_left_column,
+    _top_right_column
+  ] %}
+  {# Populate the bottom row with the corporate links. #}
+  {% set _bottom_row = [
+    [
+      {
+        'logo': {
+          'path': 'https://europa.eu/',
+          'language': current_language_id,
+          'src_mobile': _logo_path,
+          'src_desktop': _logo_path,
+        },
+        'description': logo_description,
+      },
+    ],
     [
       {
         'title': corporate_footer.contact_title,
         'links': ecl_footer_links(corporate_footer.contact),
-        'section_id': 8,
-        'title_class_name': 'ecl-footer-standardised__title--separator',
+        'title_with_separator': true,
       },
       {
         'title': corporate_footer.social_media_title,
         'links': ecl_footer_links(corporate_footer.social_media),
-        'section_id': 8,
-        'title_class_name': 'ecl-footer-standardised__title--separator',
+        'title_with_separator': true,
       },
       {
         'title': corporate_footer.legal_links_title,
         'links': ecl_footer_links(corporate_footer.legal_links),
-        'section_id': 8,
-        'title_class_name': 'ecl-footer-standardised__title--separator',
+        'title_with_separator': true,
       }
     ],
-    {
-      'title': corporate_footer.institution_links_title,
-      'links': ecl_footer_links(corporate_footer.institution_links),
-      'section_id': 9,
-      'title_class_name': 'ecl-footer-standardised__title--separator',
-    }
+    [
+      {
+        'title': corporate_footer.institution_links_title,
+        'links': ecl_footer_links(corporate_footer.institution_links),
+        'title_with_separator': true,
+      }
+    ],
   ] %}
 
   {% include '@ecl-twig/footer-standardised' with {
-    'sections': _sections,
+    'rows': [ _top_row, _bottom_row],
   } %}
 {% endblock %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -14,7 +14,6 @@
 {% extends "@oe_theme/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig" %}
 
 {% block content %}
-  {% set _logo_path = ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg' %}
   {# Populate the top row with the site identity and the custom links. #}
   {% set _top_row = [
     [
@@ -38,8 +37,8 @@
         'logo': {
           'path': 'https://europa.eu/',
           'language': current_language_id,
-          'src_mobile': _logo_path,
-          'src_desktop': _logo_path,
+          'src_mobile': ecl_logo_path ~ '/condensed-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg',
+          'src_desktop': ecl_logo_path ~ '/standard-version/positive/logo-eu--' ~ current_language_id|to_internal_language_id ~ '.svg',
         },
         'description': logo_description,
       },

--- a/tests/Functional/CorporateFooterRenderTest.php
+++ b/tests/Functional/CorporateFooterRenderTest.php
@@ -45,8 +45,6 @@ class CorporateFooterRenderTest extends BrowserTestBase {
   protected function setUp(): void {
     parent::setUp();
 
-    $this->markTestSkipped('Skip this test temporarily, as part of ECL v3 upgrade.');
-
     // Enable and set OpenEuropa Theme as default.
     $this->container->get('theme_installer')->install(['oe_theme']);
     $this->container->get('theme_handler')->setDefault('oe_theme');
@@ -76,16 +74,16 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     // Make sure that footer block is present.
     $this->assertFooterPresence('core', 4);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section1');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(1) div.ecl-footer-core__section:nth-child(1)');
 
-    $actual = $section->find('css', 'a.ecl-footer-core__title');
+    $actual = $section->find('css', 'h2.ecl-footer-core__title a');
     $this->assertEquals($data['corporate_site_link']['label'], $actual->getText());
     $this->assertEquals($data['corporate_site_link']['href'], $actual->getAttribute('href'));
 
     // Site owner is not set yet, lets make sure we don't have a description.
     $assert->elementNotExists('css', 'div.ecl-footer-core__description');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section2');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(2) div.ecl-footer-core__section:nth-child(1)');
     $items = $data['class_navigation'];
 
     foreach ($items as $key => $expected) {
@@ -94,7 +92,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'core', $expected);
     }
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section3');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(2) div.ecl-footer-core__section:nth-child(2)');
     $items = $data['service_navigation'];
 
     foreach ($items as $key => $expected) {
@@ -103,7 +101,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'core', $expected);
     }
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section4');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(2) div.ecl-footer-core__section:nth-child(3)');
     $items = $data['legal_navigation'];
 
     foreach ($items as $key => $expected) {
@@ -128,23 +126,23 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $assert = $this->assertSession();
 
     // Make sure that footer block is present.
-    $this->assertFooterPresence('standardised', 7);
+    $this->assertFooterPresence('standardised', 4);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section1');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(1) div.ecl-footer-standardised__section:nth-child(1)');
 
-    $actual = $section->find('css', 'a.ecl-footer-standardised__title');
+    $actual = $section->find('css', 'h2.ecl-footer-standardised__title a');
     $this->assertEquals('EC Site Name', $actual->getText());
     $this->assertEquals('http://web:8080/build/', $actual->getAttribute('href'));
 
     $actual = $section->find('css', 'div.ecl-footer-standardised__description');
     $this->assertEquals('This site is managed by the ACP–EU Joint Assembly', $actual->getText());
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section7');
-    $actual = $section->find('css', 'a.ecl-footer-standardised__title');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(1) div.ecl-footer-standardised__section:nth-child(1)');
+    $actual = $section->find('css', 'h2.ecl-footer-standardised__title a');
     $this->assertEquals($data['corporate_site_link']['label'], $actual->getText());
     $this->assertEquals($data['corporate_site_link']['href'], $actual->getAttribute('href'));
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section8');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(2) div.ecl-footer-standardised__section:nth-child(1)');
     $items = $data['service_navigation'];
 
     foreach ($items as $key => $expected) {
@@ -153,7 +151,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'standardised', $expected);
     }
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section9');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(3) div.ecl-footer-standardised__section:nth-child(1)');
     $items = $data['legal_navigation'];
 
     foreach ($items as $key => $expected) {
@@ -166,9 +164,9 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->updateSiteSettings('http://publications.europa.eu/resource/authority/corporate-body/DG11', 'EC Standardised Site Name');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section1');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(1) div.ecl-footer-standardised__section:nth-child(1)');
 
-    $actual = $section->find('css', 'a.ecl-footer-standardised__title');
+    $actual = $section->find('css', 'h2.ecl-footer-standardised__title a');
     $this->assertEquals('EC Standardised Site Name', $actual->getText());
     $this->assertEquals('http://web:8080/build/', $actual->getAttribute('href'));
 
@@ -186,9 +184,9 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $assert = $this->assertSession();
 
     // Make sure that footer block is present.
-    $this->assertFooterPresence('core', 6);
+    $this->assertFooterPresence('core', 5);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section1');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(1) div.ecl-footer-core__section:nth-child(1)');
 
     $actual = $assert->elementExists('css', 'div.ecl-footer-core__description');
     $this->assertEquals('This site is managed by the European Commission, DG XI – Internal Market', $actual->getText());
@@ -196,8 +194,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     // Assert presence of ecl logo in footer.
     $this->assertEclLogoPresence($section, 'core');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(1)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-core__title');
     $this->assertEquals('Contact title', $actual->getText());
@@ -210,7 +208,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'core', $expected);
     }
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(2)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-core__title');
     $this->assertEquals('Social media title', $actual->getText());
@@ -221,7 +219,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'core', $expected);
     }
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(3)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-core__section:nth-child(3)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-core__title');
     $this->assertEquals('Legal links title', $actual->getText());
@@ -234,7 +232,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'core', $expected);
     }
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-core section.ecl-footer-core__section4');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-core div.ecl-footer-core__column:nth-child(3) div.ecl-footer-core__section:nth-child(1)');
 
     $actual = $section->find('css', '.ecl-footer-core__title');
     $this->assertEquals('Institution links title', $actual->getText());
@@ -264,18 +262,18 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $assert = $this->assertSession();
 
     // Make sure that footer block is present.
-    $this->assertFooterPresence('standardised', 10);
+    $this->assertFooterPresence('standardised', 6);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section1');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(1) div.ecl-footer-standardised__section:nth-child(1)');
 
-    $actual = $section->find('css', 'a.ecl-footer-standardised__title');
+    $actual = $section->find('css', 'h2.ecl-footer-standardised__title a');
     $this->assertEquals('EU Site Name', $actual->getText());
     $this->assertEquals('http://web:8080/build/', $actual->getAttribute('href'));
 
     $actual = $assert->elementExists('css', 'div.ecl-footer-standardised__description');
     $this->assertEquals('This site is managed by the European Commission, Directorate-General for Budget', $actual->getText());
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section7');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(1) div.ecl-footer-standardised__section:nth-child(1)');
 
     $actual = $section->find('css', 'div.ecl-footer-standardised__description');
     $this->assertEquals('Discover more on <a href="https://europa.eu/" class="ecl-link ecl-link--standalone">europa.eu</a>', trim($actual->getHtml()));
@@ -283,8 +281,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     // Assert presence of ecl logo in footer.
     $this->assertEclLogoPresence($section, 'standardised');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section8');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-standardised__title');
     $this->assertEquals('Contact title', $actual->getText());
@@ -297,7 +295,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'standardised', $expected);
     }
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-standardised__title');
     $this->assertEquals('Social media title', $actual->getText());
@@ -310,7 +308,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'standardised', $expected);
     }
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $column);
 
     $actual = $subsection->find('css', '.ecl-footer-standardised__title');
     $this->assertEquals('Legal links title', $actual->getText());
@@ -323,7 +321,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
       $this->assertListLink($actual, 'standardised', $expected);
     }
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section9');
+    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(2) div.ecl-footer-standardised__column:nth-child(3) div.ecl-footer-standardised__section:nth-child(1)');
 
     $actual = $section->find('css', '.ecl-footer-standardised__title');
     $this->assertEquals('Institution links title', $actual->getText());
@@ -340,10 +338,10 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->createGeneralLink('Custom contact 1', 'contact_us');
     $this->drupalGet('<front>');
 
-    // Assert section 2 (left column) has the item,
-    // and section 3 (right column) is empty.
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    // Assert column 2 (centre column) has the item,
+    // and column 3 (right column) is empty.
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -352,14 +350,14 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $section = $assert->elementNotExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $assert->elementNotExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3) div.ecl-footer-standardised__section:nth-child(1)');
 
-    // Assert each sections 2 and 3 each have 1 item.
+    // Assert each column 2 and 3 each have 1 item.
     $this->createGeneralLink('Custom about 1', 'about_us');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -368,8 +366,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('About us', $actual->getText());
@@ -378,12 +376,12 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    // Add one more, assert odd goes into section 2, even goes into section 3.
+    // Add one more, assert odd goes into column 2, even goes into column 3.
     $this->createGeneralLink('Custom related 1', 'related_sites');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -392,7 +390,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Related sites', $actual->getText());
@@ -401,23 +399,24 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom related 1', 'href' => 'http://example.com/custom-related-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('About us', $actual->getText());
 
     $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
 
-    // Add the follow us, assert it goes last, into the left column.
+    // Add the follow us, assert it goes last, into the centre column.
     // We have 3 sub-sections plus follow, distribution should be 2 and 2.
     $this->createSocialLink('Social 1', 'facebook');
     $this->createSocialLink('Social 2', 'instagram');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -426,7 +425,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Follow us', $actual->getText());
@@ -441,17 +440,18 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('About us', $actual->getText());
 
     $actual = $subsection->find('css', 'ul li:nth-child(1) > a');
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
+    $this->assertListLink($actual, 'standardised', $expected);
 
     // Assert previous last in section 2 moved to the right into section 3.
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Related sites', $actual->getText());
@@ -461,13 +461,13 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->assertListLink($actual, 'standardised', $expected);
 
     // Assert adding a custom section in backend appears,
-    // and is placed in the footer on the right side in section 3.
+    // and is placed in the footer on the right column.
     $this->createSection('section_1', 'Section 1');
     $this->createGeneralLink('Custom link 1', 'section_1');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -478,7 +478,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     // Since we have an even number there is no switch,
     // assert Related is back in section 2.
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Related sites', $actual->getText());
@@ -488,7 +488,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->assertListLink($actual, 'standardised', $expected);
 
     // Here we assert Follow us is still on the left in section 2.
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Follow us', $actual->getText());
@@ -503,8 +503,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('About us', $actual->getText());
@@ -513,7 +513,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Section 1', $actual->getText());
@@ -529,8 +529,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     ]);
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Section 1', $actual->getText());
@@ -546,13 +546,13 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     ]);
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Section altered', $actual->getText());
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Related sites', $actual->getText());
@@ -561,9 +561,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->configFactory->getEditable('oe_theme.settings')->set('component_library', 'ec')->save();
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -572,7 +571,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('About us', $actual->getText());
@@ -581,7 +580,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom about 1', 'href' => 'http://example.com/custom-about-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(3)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Follow us', $actual->getText());
@@ -596,8 +595,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Section altered', $actual->getText());
@@ -606,7 +605,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom link altered', 'href' => 'http://example.com/custom-link-altered'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Related sites', $actual->getText());
@@ -619,9 +618,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->deleteEntity('footer_link_general', 'custom-about-1');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $section);
+    $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2)');
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(1)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertEquals('Contact us', $actual->getText());
@@ -630,7 +628,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $expected = ['label' => 'Custom contact 1', 'href' => 'http://example.com/custom-contact-1'];
     $this->assertListLink($actual, 'standardised', $expected);
 
-    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $section);
+    $subsection = $assert->elementExists('css', '.ecl-footer-standardised__section:nth-child(2)', $column);
 
     $actual = $assert->elementExists('css', '.ecl-footer-standardised__title', $subsection);
     $this->assertNotEquals('About us', $actual->getText());
@@ -656,8 +654,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->deleteEntity('footer_link_social', 'social-2');
     $this->drupalGet('<front>');
 
-    $section = $assert->elementNotExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section2');
-    $section = $assert->elementNotExists('css', 'footer.ecl-footer-standardised section.ecl-footer-standardised__section3');
+    $assert->elementNotExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(2) div.ecl-footer-standardised__section:nth-child(1)');
+    $assert->elementNotExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3) div.ecl-footer-standardised__section:nth-child(1)');
   }
 
   /**

--- a/tests/Functional/CorporateFooterRenderTest.php
+++ b/tests/Functional/CorporateFooterRenderTest.php
@@ -432,12 +432,20 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $expected = [
+      'label' => 'Social 1',
+      'href' => 'http://example.com/social-1',
+      'icon_name' => 'facebook',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
+    $expected = [
+      'label' => 'Social 2',
+      'href' => 'http://example.com/social-2',
+      'icon_name' => 'instagram',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
@@ -495,12 +503,20 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $expected = [
+      'label' => 'Social 1',
+      'href' => 'http://example.com/social-1',
+      'icon_name' => 'facebook',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
+    $expected = [
+      'label' => 'Social 2',
+      'href' => 'http://example.com/social-2',
+      'icon_name' => 'instagram',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
@@ -587,12 +603,20 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $expected = [
+      'label' => 'Social 1',
+      'href' => 'http://example.com/social-1',
+      'icon_name' => 'facebook-negative',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
+    $expected = [
+      'label' => 'Social 2',
+      'href' => 'http://example.com/social-2',
+      'icon_name' => 'instagram-negative',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $column = $assert->elementExists('css', 'footer.ecl-footer-standardised div.ecl-footer-standardised__row:nth-child(1) div.ecl-footer-standardised__column:nth-child(3)');
@@ -637,12 +661,20 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $social_link = $subsection->find('css', 'ul li:nth-child(1) > a');
     $this->assertNotEquals('Custom about 1', $social_link->getText());
     $social_label = $subsection->find('css', 'ul li:nth-child(1) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 1', 'href' => 'http://example.com/social-1'];
+    $expected = [
+      'label' => 'Social 1',
+      'href' => 'http://example.com/social-1',
+      'icon_name' => 'facebook-negative',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     $social_link = $subsection->find('css', 'ul li:nth-child(2) > a');
     $social_label = $subsection->find('css', 'ul li:nth-child(2) > a span.ecl-link__label');
-    $expected = ['label' => 'Social 2', 'href' => 'http://example.com/social-2'];
+    $expected = [
+      'label' => 'Social 2',
+      'href' => 'http://example.com/social-2',
+      'icon_name' => 'instagram-negative',
+    ];
     $this->assertSocialLink($social_label, $social_link, $expected);
 
     // Assert deleting sections in backend is reflected in the footer.
@@ -728,6 +760,8 @@ class CorporateFooterRenderTest extends BrowserTestBase {
   protected function assertSocialLink(NodeElement $label, NodeElement $link, array $expected): void {
     $this->assertEquals($expected['label'], $label->getText());
     $this->assertEquals($expected['href'], $link->getAttribute('href'));
+    $icon = $link->find('css', 'svg.ecl-icon.ecl-icon--xs.ecl-link__icon use');
+    $this->assertContains('icons-social-media.svg#' . $expected['icon_name'], $icon->getAttribute('xlink:href'));
     $this->assertEquals('ecl-link ecl-link--standalone ecl-link--icon ecl-link--icon-before ecl-footer-standardised__link', $link->getAttribute('class'));
   }
 

--- a/tests/features/corporate-blocks.feature
+++ b/tests/features/corporate-blocks.feature
@@ -24,7 +24,6 @@ Feature: Corporate blocks feature
       | the home page               |
       | the user registration page  |
 
-  @wip
   Scenario Outline: Changing the site's style will display either the European Commission or the European Union footer.
     Given I am an anonymous user
     When I am on "<page>"

--- a/tests/features/site-branding.feature
+++ b/tests/features/site-branding.feature
@@ -48,7 +48,7 @@ Feature: Site branding
       # Non-EU language.
       | Icelandic               | English    |
 
-  @javascript @enable-non-eu-language @wip
+  @javascript @enable-non-eu-language
   Scenario: The European Union logo is available in the footer when non-EU language is selected.
     Given I am on the homepage
     When the theme is configured to use the "European Union" style


### PR DESCRIPTION
## EWPP-1147

### Description

Update footer templates to use ECL V3.

### Change log

- Added:
- Changed: Update footer templates to use ECL V3.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

