### PR TITLE
EWPP-1211: Fix InPageNavigation init.

### DIFF
--- a/js/inpage_navigation.js
+++ b/js/inpage_navigation.js
@@ -59,14 +59,22 @@
         items_markup += Drupal.theme('oe_theme_inpage_navigation_item', element.getAttribute('id'), title);
       });
 
-      Array.prototype.forEach.call(document.querySelectorAll('[data-ecl-inpage-navigation]'), function (block) {
+      Array.prototype.forEach.call(document.querySelectorAll('.oe-theme-ecl-inpage-navigation'), function (block) {
         if (items_markup.length === 0) {
           // When there are no items, execute the callback to handle the block.
           Drupal.eclInPageNavigation.handleEmptyInpageNavigation(block);
           return;
         }
         block.querySelector('ul').innerHTML = items_markup;
+        var inpageNavigationInstance = new ECL.InpageNavigation(block);
+        inpageNavigationInstance.init();
+        Drupal.eclInPageNavigation.instances.push(inpageNavigation);
       })
+    },
+    detach: function detach(context, settings, trigger) {
+      Drupal.eclInPageNavigation.instances.forEach(function(inpageNavigation){
+        inpageNavigation.destroy();
+      });
     }
   };
 
@@ -83,6 +91,13 @@
      * @type {object}
      */
     seenIds: {},
+
+    /**
+     * A list of initialized ECL InPageNavigation instances.
+     *
+     * @type {Array}
+     */
+    instances: [],
 
     /**
      * Generates a unique slug from a text string.

--- a/js/inpage_navigation.js
+++ b/js/inpage_navigation.js
@@ -68,7 +68,7 @@
         block.querySelector('ul').innerHTML = items_markup;
         var inpageNavigationInstance = new ECL.InpageNavigation(block);
         inpageNavigationInstance.init();
-        Drupal.eclInPageNavigation.instances.push(inpageNavigation);
+        Drupal.eclInPageNavigation.instances.push(inpageNavigationInstance);
       })
     },
     detach: function detach(context, settings, trigger) {

--- a/js/inpage_navigation.js
+++ b/js/inpage_navigation.js
@@ -14,6 +14,8 @@
    *
    * @prop {Drupal~behaviorAttach} attach
    *   Attaches the inpage navigation behaviors.
+   * @prop {Drupal~behaviorAttach} detach
+   *   Detaches the inpage navigation behaviors.
    */
   Drupal.behaviors.eclInPageNavigation = {
     attach: function attach(context, settings) {
@@ -59,21 +61,25 @@
         items_markup += Drupal.theme('oe_theme_inpage_navigation_item', element.getAttribute('id'), title);
       });
 
+      // Loop through all the inpage navigation marked with our special class. The auto-initialisation is disabled on
+      // them, as initialisation should be run only after the items are added. Otherwise JS callbacks won't be applied
+      // correctly.
       Array.prototype.forEach.call(document.querySelectorAll('.oe-theme-ecl-inpage-navigation'), function (block) {
         if (items_markup.length === 0) {
           // When there are no items, execute the callback to handle the block.
           Drupal.eclInPageNavigation.handleEmptyInpageNavigation(block);
           return;
         }
+
         block.querySelector('ul').innerHTML = items_markup;
-        var inpageNavigationInstance = new ECL.InpageNavigation(block);
-        inpageNavigationInstance.init();
-        Drupal.eclInPageNavigation.instances.push(inpageNavigationInstance);
+        var instance = new ECL.InpageNavigation(block);
+        instance.init();
+        Drupal.eclInPageNavigation.instances.push(instance);
       })
     },
     detach: function detach(context, settings, trigger) {
-      Drupal.eclInPageNavigation.instances.forEach(function(inpageNavigation){
-        inpageNavigation.destroy();
+      Drupal.eclInPageNavigation.instances.forEach(function (instance){
+        instance.destroy();
       });
     }
   };

--- a/modules/oe_theme_helper/templates/oe-theme-helper-inpage-navigation-block.html.twig
+++ b/modules/oe_theme_helper/templates/oe-theme-helper-inpage-navigation-block.html.twig
@@ -5,8 +5,16 @@
  */
 #}
 {% block navigation %}
+  {# We add the extra attribute to guarantee the component is not auto initialized. #}
   {% include '@ecl-twig/inpage-navigation' with {
     'title': title,
     'icon_path': ecl_icon_path,
+    'extra_classes': 'oe-theme-ecl-inpage-navigation',
+    'extra_attributes': [
+      {
+        'name': 'data-ecl-auto-initialized',
+        'value': 'true'
+      }
+    ]
   } %}
 {% endblock %}


### PR DESCRIPTION
## EWPP-1211

### Description

ECL components are auto-initialised by default in oe_theme. Since the items of the inpage navigation blocks are added dynamically, the auto-init on these instances will fail to apply all the correct handlers.
To solve the issue, we prevent auto-initialisation on these instances, and execute it only after filling the items.