### PR TITLE
OEL-1362: ImageValueObject doesn't inherit cache information from image file.

### DIFF
--- a/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/MediaGalleryFormatterTest.php
+++ b/modules/oe_theme_helper/tests/src/Kernel/Plugin/Field/FieldFormatter/MediaGalleryFormatterTest.php
@@ -240,7 +240,7 @@ class MediaGalleryFormatterTest extends AbstractKernelTestBase {
     $this->assertStringContainsString('Test video iframe title', $caption->html());
     $this->assertEmpty($caption->filter('.ecl-gallery__meta')->html());
 
-    // Test that all the cache tags have present and bubbled up.
+    // Test that all the cache tags are present and have bubbled up.
     $this->assertEqualsCanonicalizing([
       'file:1',
       'file:2',

--- a/src/ValueObject/ImageValueObject.php
+++ b/src/ValueObject/ImageValueObject.php
@@ -123,7 +123,7 @@ class ImageValueObject extends ValueObjectBase implements ImageValueObjectInterf
    * @return $this
    */
   public static function fromImageItem(ImageItem $image_item): ValueObjectInterface {
-    $image_file = $image_item->get('entity')->getTarget();
+    $image_file = $image_item->get('entity')->getValue();
 
     $image_object = new static(
       file_create_url($image_file->get('uri')->getString()),
@@ -145,13 +145,13 @@ class ImageValueObject extends ValueObjectBase implements ImageValueObjectInterf
    *   The image style name.
    *
    * @return $this
-   *   A image value object instance.
+   *   An image value object instance.
    *
    * @throws \InvalidArgumentException
    *   Thrown when the image style is not found.
    */
   public static function fromStyledImageItem(ImageItem $image_item, string $style_name): ValueObjectInterface {
-    $image_file = $image_item->get('entity')->getTarget();
+    $image_file = $image_item->get('entity')->getValue();
 
     $style = \Drupal::entityTypeManager()->getStorage('image_style')->load($style_name);
     if (!$style) {

--- a/tests/src/Kernel/ValueObject/ImageValueObjectTest.php
+++ b/tests/src/Kernel/ValueObject/ImageValueObjectTest.php
@@ -96,7 +96,7 @@ class ImageValueObjectTest extends KernelTestBase {
     $this->assertEquals('This is an alternative title', $object->getAlt());
     $this->assertStringContainsString('/styles/main_style/public/example_1.jpg', $object->getSource());
 
-    // Test that all the cache tags have present and bubbled up.
+    // Test that all the cache tags are present and have bubbled up.
     $this->assertEqualsCanonicalizing([
       'config:image.style.main_style',
       'file:1',
@@ -116,7 +116,7 @@ class ImageValueObjectTest extends KernelTestBase {
     $this->assertEquals('This is an alternative title', $object->getAlt());
     $this->assertStringContainsString('/files/example_1.jpg', $object->getSource());
 
-    // Test that all the cache tags have present and bubbled up.
+    // Test that all the cache tags are present and have bubbled up.
     $this->assertEqualsCanonicalizing([
       'file:1',
     ], $object->getCacheTags());

--- a/tests/src/Kernel/ValueObject/ImageValueObjectTest.php
+++ b/tests/src/Kernel/ValueObject/ImageValueObjectTest.php
@@ -17,7 +17,7 @@ use Drupal\Tests\token\Kernel\KernelTestBase;
  *
  * @group batch2
  */
-class ImageTest extends KernelTestBase {
+class ImageValueObjectTest extends KernelTestBase {
 
   /**
    * {@inheritdoc}
@@ -28,6 +28,13 @@ class ImageTest extends KernelTestBase {
     'entity_test',
     'field',
   ];
+
+  /**
+   * Entity object.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  protected $entity;
 
   /**
    * {@inheritdoc}
@@ -56,44 +63,63 @@ class ImageTest extends KernelTestBase {
 
     // Copy file in public files to use it for styling.
     \Drupal::service('file_system')->copy(__DIR__ . '/../../../fixtures/example_1.jpeg', 'public://example_1.jpg');
-  }
 
-  /**
-   * Test the image value object has the correct style applied.
-   */
-  public function testFromStyledImageItem() {
     // Create image file.
     $image = File::create([
       'uri' => 'public://example_1.jpg',
     ]);
     $image->save();
 
+    // Create an image item.
+    $this->entity = EntityTest::create([
+      'name' => $this->randomString(),
+      'field_image' => [
+        'target_id' => $image->id(),
+        'alt' => 'This is an alternative title',
+        'title' => 'This is a title',
+      ],
+    ]);
+    $this->entity->save();
+  }
+
+  /**
+   * Tests the ::fromStyledImageItem method.
+   */
+  public function testFromStyledImageItem() {
     // Create a test style.
     /** @var \Drupal\image\ImageStyleInterface $style */
     $style = ImageStyle::create(['name' => 'main_style']);
     $style->save();
 
-    // Create an image item.
-    $alt = $this->randomString();
-    $title = $this->randomString();
-    $entity = EntityTest::create([
-      'name' => $this->randomString(),
-      'field_image' => [
-        'target_id' => $image->id(),
-        'alt' => $alt,
-        'title' => $title,
-      ],
-    ]);
-    $entity->save();
-
-    $object = ImageValueObject::fromStyledImageItem($entity->get('field_image')->first(), $style->getName());
-    $this->assertEquals($title, $object->getName());
-    $this->assertEquals($alt, $object->getAlt());
+    $object = ImageValueObject::fromStyledImageItem($this->entity->get('field_image')->first(), $style->getName());
+    $this->assertEquals('This is a title', $object->getName());
+    $this->assertEquals('This is an alternative title', $object->getAlt());
     $this->assertStringContainsString('/styles/main_style/public/example_1.jpg', $object->getSource());
+
+    // Test that all the cache tags have present and bubbled up.
+    $this->assertEqualsCanonicalizing([
+      'config:image.style.main_style',
+      'file:1',
+    ], $object->getCacheTags());
 
     $invalid_image_style = $this->randomMachineName();
     $this->expectExceptionObject(new \InvalidArgumentException(sprintf('Could not load image style with name "%s".', $invalid_image_style)));
-    ImageValueObject::fromStyledImageItem($entity->get('field_image')->first(), $invalid_image_style);
+    ImageValueObject::fromStyledImageItem($this->entity->get('field_image')->first(), $invalid_image_style);
+  }
+
+  /**
+   * Tests the ::fromImageItem method.
+   */
+  public function testFromImageItem() {
+    $object = ImageValueObject::fromImageItem($this->entity->get('field_image')->first());
+    $this->assertEquals('This is a title', $object->getName());
+    $this->assertEquals('This is an alternative title', $object->getAlt());
+    $this->assertStringContainsString('/files/example_1.jpg', $object->getSource());
+
+    // Test that all the cache tags have present and bubbled up.
+    $this->assertEqualsCanonicalizing([
+      'file:1',
+    ], $object->getCacheTags());
   }
 
 }

--- a/tests/src/Unit/ValueObject/ImageValueObjectTest.php
+++ b/tests/src/Unit/ValueObject/ImageValueObjectTest.php
@@ -67,7 +67,7 @@ class ImageValueObjectTest extends UnitTestCase {
     $this->imageFile->get('uri')->willReturn($this->imageUri->reveal());
 
     $this->imageEntity = $this->prophesize(EntityReference::class);
-    $this->imageEntity->getTarget()->willReturn($this->imageFile->reveal());
+    $this->imageEntity->getValue()->willReturn($this->imageFile->reveal());
 
     $this->imageReferenceItem = $this->prophesize(ImageItem::class);
     $this->imageReferenceItem->get('entity')->willReturn($this->imageEntity->reveal());
@@ -84,7 +84,7 @@ class ImageValueObjectTest extends UnitTestCase {
   }
 
   /**
-   * Test constructing a image value object from an array.
+   * Test constructing an image value object from an array.
    */
   public function testFromArray() {
     $data = [
@@ -104,7 +104,7 @@ class ImageValueObjectTest extends UnitTestCase {
   }
 
   /**
-   * Test constructing a image value object from an image item.
+   * Test constructing an image value object from an image item.
    */
   public function testFromImageItem() {
     /** @var \Drupal\oe_theme\ValueObject\ImageValueObject $object */

--- a/tests/src/Unit/ValueObject/ImageValueObjectTest.php
+++ b/tests/src/Unit/ValueObject/ImageValueObjectTest.php
@@ -2,13 +2,8 @@
 
 declare(strict_types = 1);
 
-namespace Drupal\Tests\oe_theme\Unit\Patterns;
+namespace Drupal\Tests\oe_theme\Unit\ValueObject;
 
-use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
-use Drupal\Core\Entity\Plugin\DataType\EntityReference;
-use Drupal\Core\Field\FieldItemList;
-use Drupal\Core\TypedData\Plugin\DataType\StringData;
-use Drupal\image\Plugin\Field\FieldType\ImageItem;
 use Drupal\oe_theme\ValueObject\ImageValueObject;
 use Drupal\Tests\UnitTestCase;
 
@@ -18,70 +13,6 @@ use Drupal\Tests\UnitTestCase;
  * @group batch1
  */
 class ImageValueObjectTest extends UnitTestCase {
-
-  /**
-   * Mock ImageItem object.
-   *
-   * @var \Drupal\image\Plugin\Field\FieldType\ImageItem|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $imageReferenceItem;
-
-  /**
-   * Mock EntityAdapter object.
-   *
-   * @var \Drupal\Core\Entity\Plugin\DataType\EntityAdapter|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $imageFile;
-
-  /**
-   * Mock EntityReference object.
-   *
-   * @var \Drupal\Core\Entity\Plugin\DataType\EntityReference|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $imageEntity;
-
-  /**
-   * Mock FieldItemList object.
-   *
-   * @var \Drupal\Core\Field\FieldItemList|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $imageUri;
-
-  /**
-   * Mock StringData object.
-   *
-   * @var \Drupal\Core\TypedData\Plugin\DataType\StringData|\Prophecy\Prophecy\ObjectProphecy
-   */
-  protected $imageAltText;
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function setUp(): void {
-    parent::setUp();
-
-    $this->imageUri = $this->prophesize(FieldItemList::class);
-    $this->imageUri->getString()->willReturn('http://placehold.it/380x185');
-
-    $this->imageFile = $this->prophesize(EntityAdapter::class);
-    $this->imageFile->get('uri')->willReturn($this->imageUri->reveal());
-
-    $this->imageEntity = $this->prophesize(EntityReference::class);
-    $this->imageEntity->getValue()->willReturn($this->imageFile->reveal());
-
-    $this->imageReferenceItem = $this->prophesize(ImageItem::class);
-    $this->imageReferenceItem->get('entity')->willReturn($this->imageEntity->reveal());
-
-    $this->imageAltText = $this->prophesize(StringData::class);
-    $this->imageAltText->getString()->willReturn('Alt text');
-
-    $this->imageReferenceItem->get('alt')->willReturn($this->imageAltText->reveal());
-
-    $this->imageTitleText = $this->prophesize(StringData::class);
-    $this->imageTitleText->getString()->willReturn('Test image');
-
-    $this->imageReferenceItem->get('title')->willReturn($this->imageTitleText->reveal());
-  }
 
   /**
    * Test constructing an image value object from an array.
@@ -101,45 +32,6 @@ class ImageValueObjectTest extends UnitTestCase {
     $this->assertEquals($data['name'], $object->getName());
     $this->assertEquals($data['alt'], $object->getAlt());
     $this->assertEquals($data['responsive'], $object->isResponsive());
-  }
-
-  /**
-   * Test constructing an image value object from an image item.
-   */
-  public function testFromImageItem() {
-    /** @var \Drupal\oe_theme\ValueObject\ImageValueObject $object */
-    $object = ImageValueObject::fromImageItem($this->imageReferenceItem->reveal());
-
-    $this->assertEquals('http://placehold.it/380x185', $object->getSource());
-    $this->assertEquals('Test image', $object->getName());
-    $this->assertEquals('Alt text', $object->getAlt());
-    $this->assertEquals(TRUE, $object->isResponsive());
-  }
-
-}
-
-/**
- * Mocking file_create_url().
- *
- * ImageValueObject uses file_create_url()
- * which is available when using the Simpletest test runner, but not when
- * using the PHPUnit test runner; hence this hack.
- */
-namespace Drupal\oe_theme\ValueObject;
-
-if (!function_exists('Drupal\oe_theme\ValueObject\file_create_url')) {
-
-  /**
-   * Mock for file_create_url().
-   *
-   * @param string $uri
-   *   Uri to be processed.
-   *
-   * @return string
-   *   Processed url.
-   */
-  function file_create_url($uri): string {
-    return $uri;
   }
 
 }


### PR DESCRIPTION
## OPENEUROPA-OEL-1362

### Description

In oe_bootstrap_theme we updated the ImageValueObject. The idea is align both ImageValueObject class and tests.

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

