### PR TITLE
EWPP-2928: Make sure that field_oe_link in oe_theme_preprocess_paragraph__oe_list_item is not empty.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -812,13 +812,15 @@ function oe_theme_preprocess_paragraph__oe_list_item(array &$variables): void {
 
   $list_item_variant = $paragraph->get('oe_paragraphs_variant')->first()->value;
   $variables['variant'] = $list_item_variant ?? 'default';
-  $url = $paragraph->get('field_oe_link')->first()->getUrl();
-  if (!$url->isRouted() || !in_array($url->getRouteName(), [
-    '<nolink>',
-    '<button>',
-  ])) {
-    $variables['url'] = $url;
-    $variables['external_link'] = \Drupal::service('oe_theme_helper.external_links')->isExternalLink($url);
+  if (!$paragraph->get('field_oe_link')->isEmpty()) {
+    $url = $paragraph->get('field_oe_link')->first()->getUrl();
+    if (!$url->isRouted() || !in_array($url->getRouteName(), [
+      '<nolink>',
+      '<button>',
+    ])) {
+      $variables['url'] = $url;
+      $variables['external_link'] = \Drupal::service('oe_theme_helper.external_links')->isExternalLink($url);
+    }
   }
 
   $cacheability = CacheableMetadata::createFromRenderArray($variables);


### PR DESCRIPTION
…ook implementation to not include item without required fields.

## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

