### PR TITLE
EJPREV-134: Suppress errors notice on oe_paragraph.

### DIFF
--- a/src/ValueObject/ValueObjectBase.php
+++ b/src/ValueObject/ValueObjectBase.php
@@ -19,6 +19,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists($offset) {
     return array_key_exists($offset, $this->getArray());
   }
@@ -26,6 +27,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function getIterator() {
     return new \ArrayIterator($this->getArray());
   }
@@ -33,6 +35,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet($offset) {
     return $this->getArray()[$offset];
   }
@@ -40,6 +43,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetSet($offset, $value) {
     // Does nothing as a value object array access is meant to be read-only.
   }
@@ -47,6 +51,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetUnset($offset) {
     // Does nothing as a value object array access is meant to be read-only.
   }


### PR DESCRIPTION
### Description

Deprecation error notice display where oe_banner is loaded:

> Deprecated: Return type of Drupal\oe_theme\ValueObject\ValueObjectBase::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice 

### Change log

- Fixed: Suppress deprecation error by adding annotation on ValueObjectBase class.

