### PR TITLE
Deprecated return type oe paragraphs error

### DIFF
--- a/src/ValueObject/ValueObjectBase.php
+++ b/src/ValueObject/ValueObjectBase.php
@@ -19,6 +19,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetExists(mixed $offset): bool {
     return array_key_exists($offset, $this->getArray());
   }
@@ -34,6 +35,7 @@ abstract class ValueObjectBase implements ValueObjectInterface {
   /**
    * {@inheritdoc}
    */
+  #[\ReturnTypeWillChange]
   public function offsetGet(mixed $offset): mixed {
     return $this->getArray()[$offset];
   }


### PR DESCRIPTION
Description
Deprecation error notice display where oe_banner is loaded:

Deprecated: Return type of Drupal\oe_theme\ValueObject\ValueObjectBase::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Change log
Fixed: Suppress deprecation error by adding annotation on ValueObjectBase class.


