### PR TITLE
EWPP-3083: Make timeline field always show the last item.

### DIFF
--- a/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/ProgrammeExtraField.php
+++ b/modules/oe_theme_content_event/src/Plugin/ExtraField/Display/ProgrammeExtraField.php
@@ -185,6 +185,7 @@ class ProgrammeExtraField extends EventExtraFieldBase {
     }
 
     $build['#fields']['items'] = $items;
+    $build['#fields']['limit_to'] = count($items) - 1;
     $cache->addCacheContexts(['timezone']);
     $cache->applyTo($build);
 

--- a/templates/field/timeline.html.twig
+++ b/templates/field/timeline.html.twig
@@ -6,6 +6,7 @@
 #}
 {{ pattern('timeline', {
   'limit': limit,
+  'limit_to': items | length - 1,
   'button_label': show_more,
   'items': items,
 }) }}

--- a/tests/src/Kernel/TimelineTest.php
+++ b/tests/src/Kernel/TimelineTest.php
@@ -160,6 +160,12 @@ class TimelineTest extends AbstractKernelTestBase {
           'body' => 'Item 3 body',
           'format' => 'my_text_format',
         ],
+        [
+          'label' => '16/07/2019',
+          'title' => 'Item 4',
+          'body' => 'Item 4 body',
+          'format' => 'my_text_format',
+        ],
       ],
     ];
 
@@ -176,16 +182,16 @@ class TimelineTest extends AbstractKernelTestBase {
     // Assert the timeline items are the number of entries plus one for the
     // "See more" button.
     $timeline_item = $crawler->filter('.ecl-timeline__item');
-    $this->assertCount(4, $timeline_item);
+    $this->assertCount(5, $timeline_item);
 
     $timeline_body = $crawler->filter('.ecl-timeline__label');
-    $this->assertCount(3, $timeline_body);
+    $this->assertCount(4, $timeline_body);
 
     $timeline_title = $crawler->filter('.ecl-timeline__title');
-    $this->assertCount(3, $timeline_title);
+    $this->assertCount(4, $timeline_title);
 
     $timeline_body = $crawler->filter('.ecl-timeline__content');
-    $this->assertCount(3, $timeline_body);
+    $this->assertCount(4, $timeline_body);
 
     $hidden_timeline_item = $crawler->filter('.ecl-timeline__item--collapsed');
     $this->assertCount(1, $hidden_timeline_item);


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

