### PR TITLE
Issue #1193: Smart Trim module upgrade.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": ">=8.0",
         "cweagans/composer-patches": "~1.4",
         "drupal/core": "^9.4",
-        "drupal/smart_trim": "^1.2",
+        "drupal/smart_trim": "^2.0",
         "drupal/twig_field_value": "^2.0",
         "drupal/ui_patterns": "^1.5",
         "openeuropa/ecl-twig-loader": "^3.1",

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -16,7 +16,7 @@ use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Template\Attribute;
 use Drupal\oe_theme_helper\EuropeanUnionLanguages;
 use Drupal\oe_theme_helper\ExternalLinksInterface;
-use Drupal\smart_trim\Truncate\TruncateHTML;
+use Drupal\smart_trim\TruncateHTML;
 use Drupal\Core\Template\TwigExtension as CoreTwigExtension;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
@@ -459,6 +459,9 @@ class TwigExtension extends AbstractExtension {
    *   The trimmed output.
    */
   public function smartTrim(Environment $env, $input, $limit) {
+    // Ensure that $limit is always a integer.
+    $limit = intval($limit);
+
     // Bubbles Twig template argument's cacheability & attachment metadata.
     $this->bubbleArgMetadata($input);
     $truncate = new TruncateHTML();


### PR DESCRIPTION
## OPENEUROPA-000

## OES-2364
( [OES-2364](https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OES-2364) I couldn't find OPENEUROPA in jira ) 
### Description
close https://github.com/openeuropa/oe_theme/issues/1193
Upgrade `drupal/smart_trim` to version 2.0.0

### Change log
- Changed:
  - Upgrade `drupal/smart_trim` to version 2.0.0
  - Ensure that $limit is always a integer to prevent type hint errors.


### Commands

```sh
docker-compose up -d


docker-compose exec -u node node npm install
docker-compose exec -u node node npm run build
docker-compose exec web composer install
docker-compose exec web ./vendor/bin/run drupal:site-install

```

