### PR TITLE
EWPP-3826: Remove spaceless filter

### DIFF
--- a/templates/field/field--text-long.html.twig
+++ b/templates/field/field--text-long.html.twig
@@ -1,23 +1,21 @@
-{#
+{#-
 /**
  * @file
  * Theme override for the text long fields.
  *
  * @see ./core/themes/stable/templates/field/field.html.twig
  */
-#}
-{% apply spaceless %}
-  {% if not label_hidden %}
-    {%
-      set title_classes = [
-      'ecl-u-type-bold',
-      'ecl-u-mb-m',
-      label_display == 'visually_hidden' ? 'visually-hidden',
-    ]
-    %}
-    <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
-  {% endif %}
-  <div class="ecl">
-    {%- include 'field--bare.html.twig' -%}
-  </div>
-{% endapply %}
+-#}
+{%- if not label_hidden -%}
+  {%-
+    set title_classes = [
+    'ecl-u-type-bold',
+    'ecl-u-mb-m',
+    label_display == 'visually_hidden' ? 'visually-hidden',
+  ]
+  -%}
+  <div{{ title_attributes.addClass(title_classes) }}>{{ label }}</div>
+{%- endif -%}
+<div class="ecl">
+  {%- include 'field--bare.html.twig' -%}
+</div>


### PR DESCRIPTION
Remove spaceless filter, use "-" instead.

I don't know if all of the "-" are really needed. See what happens with or without.

## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

