### PR TITLE
Fix issue https://github.com/openeuropa/oe_theme/issues/1037

### DIFF
--- a/js/ecl_datepicker.js
+++ b/js/ecl_datepicker.js
@@ -5,7 +5,7 @@
 (function (ECL, Drupal) {
   Drupal.behaviors.eclDatepicker = {
     attach: function attach(context, settings) {
-      var elements = document.querySelectorAll('[data-ecl-datepicker-toggle]');
+      var elements = once('ecl-datepicker', document.querySelectorAll('[data-ecl-datepicker-toggle]'));
       for (var i = 0; i < elements.length; i++) {
         var datepicker = new ECL.Datepicker(elements[i], {
           format: settings.oe_theme.ecl_datepicker_format

--- a/oe_theme.libraries.yml
+++ b/oe_theme.libraries.yml
@@ -55,6 +55,7 @@ ecl_datepicker:
     js/ecl_datepicker.js: {}
   dependencies:
     - core/drupal
+    - core/once
     - core/jquery
 
 print:


### PR DESCRIPTION
## OPENEUROPA-1037
### Description

Provides a fix for issue https://github.com/openeuropa/oe_theme/issues/1037 so that datepicker works for websites having BigPipe enabled too.

### Change log

- Added: Add dependency on "core/once".
- Changed: The added dependency requires at least Drupal 9.2 according to https://www.drupal.org/node/3158256
- Deprecated: -
- Removed:-
- Fixed: https://github.com/openeuropa/oe_theme/issues/1037
- Security: -
