### PR TITLE
EWPP-4401: Pass hide_label variable to the social media links pattern.

### DIFF
--- a/templates/patterns/social_media_links/pattern-social-media-links.html.twig
+++ b/templates/patterns/social_media_links/pattern-social-media-links.html.twig
@@ -12,6 +12,7 @@
       path: link.url,
       label: link.label,
       icon_position: 'before',
+      hide_label: link.hide_label|default(false),
     }
   } %}
   {% if link.service is not empty %}

--- a/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
+++ b/templates/patterns/social_media_links/social_media_links.ui_patterns.yml
@@ -28,5 +28,6 @@ social_media_links:
         - service: "instagram"
           label: "Instagram"
           url: "#"
+          hide_label: true
         - label: "See more"
           url: "#"


### PR DESCRIPTION
## EWPP-4401

### Description

EWPP CMS defines a field that allows to hide social media labels, leaving only icons. However, the `hide_label` parameter is not passed to the pattern.


