### PR TITLE
UCPKN-3176: Accessibility statement link in the footer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "phpspec/prophecy-phpunit": "^2",
         "symfony/phpunit-bridge": "^6.0"
     },
+    "conflict": {
+        "openeuropa/oe_corporate_blocks": "<=4.19.2"
+    },
     "scripts": {
         "post-install-cmd": "./vendor/bin/run drupal:site-setup",
         "post-update-cmd": "./vendor/bin/run drupal:site-setup"

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "openeuropa/code-review": "^2.0.0-alpha6",
         "openeuropa/oe_contact_forms": "^1.14",
         "openeuropa/oe_content": "^4.0.0",
-        "openeuropa/oe_corporate_blocks": "dev-contribution/UCPKN-3176",
+        "openeuropa/oe_corporate_blocks": "4.x-dev",
         "openeuropa/oe_corporate_countries": "^2.0.0",
         "openeuropa/oe_corporate_site_info": "^1.0.0-alpha8",
         "openeuropa/oe_media": "^1.27",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "openeuropa/code-review": "^2.0.0-alpha6",
         "openeuropa/oe_contact_forms": "^1.14",
         "openeuropa/oe_content": "^4.0.0",
-        "openeuropa/oe_corporate_blocks": "^4.19",
+        "openeuropa/oe_corporate_blocks": "dev-contribution/UCPKN-3176",
         "openeuropa/oe_corporate_countries": "^2.0.0",
         "openeuropa/oe_corporate_site_info": "^1.0.0-alpha8",
         "openeuropa/oe_media": "^1.27",

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -665,13 +665,13 @@ class TwigExtension extends AbstractExtension {
   /**
    * Checks if a given path is external or not.
    *
-   * @param string $path
+   * @param mixed $path
    *   The path to be checked.
    *
    * @return bool
    *   Whether the path is external.
    */
-  public function isExternal(string $path): bool {
+  public function isExternal(mixed $path): bool {
     return $this->externalLinks->isExternalLink($path);
   }
 

--- a/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
+++ b/modules/oe_theme_helper/src/TwigExtension/TwigExtension.php
@@ -665,13 +665,13 @@ class TwigExtension extends AbstractExtension {
   /**
    * Checks if a given path is external or not.
    *
-   * @param mixed $path
+   * @param string $path
    *   The path to be checked.
    *
    * @return bool
    *   Whether the path is external.
    */
-  public function isExternal(mixed $path): bool {
+  public function isExternal(string $path): bool {
     return $this->externalLinks->isExternalLink($path);
   }
 

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1840,14 +1840,7 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
     $variables['path'] = 'https://commission.europa.eu/index_' . EuropeanUnionLanguages::getInternalLanguageCode($variables['current_language_id']);
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
-
-  if (function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
-    oe_corporate_blocks_preprocess_set_accessibility_link($variables);
-
-    if (isset($variables['accessibility_link']) && $variables['accessibility_link'] instanceof Url) {
-      $variables['accessibility_link'] = $variables['accessibility_link']->toString();
-    }
-  }
+  _oe_theme_preprocess_accessibility_link($variables);
 }
 
 /**
@@ -1868,14 +1861,7 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
   $variables['mobile_logo_path'] = str_replace('standard', 'condensed', $variables['desktop_logo_path']);
 
   _oe_theme_preprocess_site_specific_footer_links($variables);
-
-  if (function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
-    oe_corporate_blocks_preprocess_set_accessibility_link($variables);
-
-    if (isset($variables['accessibility_link']) && $variables['accessibility_link'] instanceof Url) {
-      $variables['accessibility_link'] = $variables['accessibility_link']->toString();
-    }
-  }
+  _oe_theme_preprocess_accessibility_link($variables);
 
   // Hide the default Accessibility link inside "Legal" section for
   // standardised ECL branding.
@@ -1949,6 +1935,23 @@ function _oe_theme_preprocess_site_specific_footer_links(array &$variables): voi
       }
     }
   }
+}
+
+/**
+ * Get the Accessibility statement link.
+ */
+function _oe_theme_preprocess_accessibility_link(array &$variables) {
+  if (!function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
+    return;
+  }
+
+  oe_corporate_blocks_preprocess_set_accessibility_link($variables);
+
+  if (!isset($variables['accessibility_link']) || !$variables['accessibility_link'] instanceof Url) {
+    return;
+  }
+
+  $variables['accessibility_link'] = $variables['accessibility_link']->toString();
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1840,7 +1840,6 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
     $variables['path'] = 'https://commission.europa.eu/index_' . EuropeanUnionLanguages::getInternalLanguageCode($variables['current_language_id']);
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  _oe_theme_preprocess_accessibility_link($variables);
 }
 
 /**
@@ -1861,7 +1860,6 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
   $variables['mobile_logo_path'] = str_replace('standard', 'condensed', $variables['desktop_logo_path']);
 
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  _oe_theme_preprocess_accessibility_link($variables);
 
   // Hide the default Accessibility link inside "Legal" section for
   // standardised ECL branding.
@@ -1935,23 +1933,6 @@ function _oe_theme_preprocess_site_specific_footer_links(array &$variables): voi
       }
     }
   }
-}
-
-/**
- * Get the Accessibility statement link.
- */
-function _oe_theme_preprocess_accessibility_link(array &$variables) {
-  if (!function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
-    return;
-  }
-
-  oe_corporate_blocks_preprocess_set_accessibility_link($variables);
-
-  if (!isset($variables['accessibility_link']) || !$variables['accessibility_link'] instanceof Url) {
-    return;
-  }
-
-  $variables['accessibility_link'] = $variables['accessibility_link']->toString();
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -28,7 +28,6 @@ use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalSourceInterface;
 use Drupal\media_avportal\Plugin\media\Source\MediaAvPortalVideoSource;
 use Drupal\node\NodeInterface;
 use Drupal\oe_content_person\Entity\PersonJobInterface;
-use Drupal\oe_corporate_site_info\SiteInformation;
 use Drupal\oe_media_iframe\Plugin\media\Source\Iframe;
 use Drupal\oe_theme\DocumentMediaValueExtractor;
 use Drupal\oe_theme\ValueObject\DateValueObject;
@@ -1841,7 +1840,12 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
     $variables['path'] = 'https://commission.europa.eu/index_' . EuropeanUnionLanguages::getInternalLanguageCode($variables['current_language_id']);
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  _oe_theme_preprocess_accessibility_link($variables);
+  if (\Drupal::service('module_handler')->moduleExists('oe_corporate_blocks')) {
+    oe_corporate_blocks_preprocess_set_accessibility_link($variables);
+    if ($variables['accessibility_link']) {
+      $variables['accessibility_link'] = $variables['accessibility_link']->toString();
+    }
+  }
 }
 
 /**
@@ -1862,7 +1866,12 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
   $variables['mobile_logo_path'] = str_replace('standard', 'condensed', $variables['desktop_logo_path']);
 
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  _oe_theme_preprocess_accessibility_link($variables);
+  if (\Drupal::service('module_handler')->moduleExists('oe_corporate_blocks')) {
+    oe_corporate_blocks_preprocess_set_accessibility_link($variables);
+    if ($variables['accessibility_link']) {
+      $variables['accessibility_link'] = $variables['accessibility_link']->toString();
+    }
+  }
 
   // Hide the default Accessibility link inside "Legal" section for
   // standardised ECL branding.
@@ -1936,44 +1945,6 @@ function _oe_theme_preprocess_site_specific_footer_links(array &$variables): voi
       }
     }
   }
-}
-
-/**
- * Get the Accessibility statement link.
- */
-function _oe_theme_preprocess_accessibility_link(array &$variables) {
-  if (!\Drupal::service('module_handler')->moduleExists('oe_corporate_site_info')) {
-    return;
-  }
-  $cacheability = CacheableMetadata::createFromRenderArray($variables);
-  $configuration = \Drupal::configFactory()->get(SiteInformation::CONFIG_NAME);
-  $cacheability->addCacheableDependency($configuration);
-  /** @var \Drupal\oe_corporate_site_info\SiteInformationInterface $site_information */
-  $site_information = \Drupal::service('oe_corporate_site_info.site_information');
-  if (!$site_information->hasAccessibilityLink()) {
-    $cacheability->applyTo($variables);
-    return;
-  }
-  $uri = $site_information->getAccessibilityLink();
-  $uri_parts = parse_url($uri);
-  if ($uri_parts['scheme'] === 'entity') {
-    [$entity_type_id, $entity_id] = explode('/', $uri_parts['path'], 2);
-    $entity = \Drupal::entityTypeManager()->getStorage($entity_type_id)->load($entity_id);
-    if ($entity instanceof NodeInterface) {
-      $cacheability->addCacheableDependency($entity);
-      $access = $entity->access('view', \Drupal::currentUser(), TRUE);
-      $cacheability->addCacheableDependency($access);
-      if (!$access->isAllowed()) {
-        $cacheability->applyTo($variables);
-        // Do not show the button if access to the node is forbidden.
-        return;
-      }
-    }
-  }
-  $url = Url::fromUri($uri)->toString();
-
-  $variables['accessibility_link'] = $url;
-  $cacheability->applyTo($variables);
 }
 
 /**

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1840,9 +1840,11 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
     $variables['path'] = 'https://commission.europa.eu/index_' . EuropeanUnionLanguages::getInternalLanguageCode($variables['current_language_id']);
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  if (\Drupal::service('module_handler')->moduleExists('oe_corporate_blocks')) {
+
+  if (function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
     oe_corporate_blocks_preprocess_set_accessibility_link($variables);
-    if ($variables['accessibility_link']) {
+
+    if (isset($variables['accessibility_link']) && $variables['accessibility_link'] instanceof Url) {
       $variables['accessibility_link'] = $variables['accessibility_link']->toString();
     }
   }
@@ -1866,9 +1868,11 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
   $variables['mobile_logo_path'] = str_replace('standard', 'condensed', $variables['desktop_logo_path']);
 
   _oe_theme_preprocess_site_specific_footer_links($variables);
-  if (\Drupal::service('module_handler')->moduleExists('oe_corporate_blocks')) {
+
+  if (function_exists('oe_corporate_blocks_preprocess_set_accessibility_link')) {
     oe_corporate_blocks_preprocess_set_accessibility_link($variables);
-    if ($variables['accessibility_link']) {
+
+    if (isset($variables['accessibility_link']) && $variables['accessibility_link'] instanceof Url) {
       $variables['accessibility_link'] = $variables['accessibility_link']->toString();
     }
   }

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1840,6 +1840,7 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
     $variables['path'] = 'https://commission.europa.eu/index_' . EuropeanUnionLanguages::getInternalLanguageCode($variables['current_language_id']);
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
+  _oe_theme_preprocess_accessibility_link($variables);
 }
 
 /**
@@ -1860,6 +1861,7 @@ function oe_theme_preprocess_oe_corporate_blocks_eu_footer(array &$variables) {
   $variables['mobile_logo_path'] = str_replace('standard', 'condensed', $variables['desktop_logo_path']);
 
   _oe_theme_preprocess_site_specific_footer_links($variables);
+  _oe_theme_preprocess_accessibility_link($variables);
 
   // Hide the default Accessibility link inside "Legal" section for
   // standardised ECL branding.
@@ -1933,6 +1935,17 @@ function _oe_theme_preprocess_site_specific_footer_links(array &$variables): voi
       }
     }
   }
+}
+
+/**
+ * Get the Accessibility statement link.
+ */
+function _oe_theme_preprocess_accessibility_link(array &$variables) {
+  if (!isset($variables['accessibility_link']) || !$variables['accessibility_link'] instanceof Url) {
+    return;
+  }
+
+  $variables['accessibility_link'] = $variables['accessibility_link']->toString();
 }
 
 /**


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

The accessibility statement link logic is in the oe_coporate_blocks module from now. See https://github.com/openeuropa/oe_corporate_blocks/pull/155

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

