### PR TITLE
Issue #1455: Allowing optional name attribute to be empty

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1248,7 +1248,7 @@ function _oe_theme_preprocess_search_input_text(array $element): array {
   // Process element attributes into an ECL input array.
   $ecl_array = [
     'id' => $element['#attributes']['id'],
-    'name' => $element['#attributes']['name'],
+    'name' => $element['#attributes']['name'] ?? '',
     'disabled' => $element['#attributes']['disabled'] ?? FALSE,
     'type' => $element['#attributes']['type'],
     'class' => $element['#attributes']['class'],


### PR DESCRIPTION
## OPENEUROPA-1455

### Description

The name attribute is optional in Drupal. The OE theme requires this. This gives a warning for example Admin Toolbar Search.

### Change log

- Changed: Made name attribute optional in search form fields.


