### PR TITLE
EWPP-5343: Fix duplicated IDs in select and multiselect facets.

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -425,7 +425,7 @@ function oe_theme_preprocess_fieldset(array &$variables): void {
  * label is already rendered in the input template.
  */
 function oe_theme_preprocess_form_element(array &$variables): void {
-  if (in_array($variables['element']['#type'], ['checkbox', 'radio'])) {
+  if (in_array($variables['element']['#type'], ['checkbox', 'radio', 'select'])) {
     $variables['label_display'] = 'none';
   }
   $ecl_type_mappings = [
@@ -2501,6 +2501,18 @@ function oe_theme_preprocess_select(&$variables) {
     $variables['classes'] = implode(' ', $attributes['class']);
     unset($attributes['class']);
   }
+
+  // Unset the ID field, as it collides with the ID of the <select>.
+  unset($attributes['id']);
+
+  // Unset the parameters that do not belong to the <div> element.
+  unset($attributes['name']);
+  unset($attributes['multiple']);
+
+  // Set the label here and let ECL decide how to focus input elements.
+  // This will work both for select and multiselect form widgets.
+  $variables['label'] = $variables['element']['#title'] ?? '';
+
   foreach ($attributes as $name => $value) {
     $variables['extra_attributes'][] = [
       'name' => $name,

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -56,6 +56,7 @@
 {% endfor %}
 
 {% include '@ecl-twig/form-group' with {
+  label: label,
   id: attributes.id,
   name: attributes.name,
   input: {

--- a/tests/src/FunctionalJavascript/JavascriptBehavioursTest.php
+++ b/tests/src/FunctionalJavascript/JavascriptBehavioursTest.php
@@ -127,6 +127,16 @@ class JavascriptBehavioursTest extends WebDriverTestBase {
     $select_dropdown = $this->getSession()->getPage()->find('css', 'div.ecl-select__multiple-dropdown.ecl-select__container.ecl-select__container--m');
     Assert::assertFalse($this->getSession()->getDriver()->isVisible($select_dropdown->getXpath()));
 
+    // Assert the label is present and it points to the right id.
+    $form_item = $this->getSession()->getPage()->find('css', 'div.form-item-multi-select');
+    $form_label = $form_item->find('css', 'label');
+    $this->assertEquals('edit-multi-select-toggle', $form_label->getAttribute('for'));
+
+    // Assert the form group does not have an ID taken from the <select>.
+    $form_group = $form_item->find('css', '.ecl-form-group');
+    $form_select = $form_group->find('css', 'select');
+    $this->assertNotEquals($form_select->getAttribute('id'), $form_group->getAttribute('id'));
+
     // Click the input and assert the dropdown is now visible.
     $select_input->click();
     $select_dropdown = $this->getSession()->getPage()->find('css', 'div.ecl-select__multiple-dropdown.ecl-select__container.ecl-select__container--m');


### PR DESCRIPTION
## EWPP-5343

### Description

Fix the select and multiselect labels by de-duplicating "id" attributes and setting proper "for" attributes.


