### PR TITLE
EWPP-5369: Move the "Report an IT vulnerability" link

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,9 @@
             },
             "drupal/address": {
                 "https://www.drupal.org/project/address/issues/3144823": "https://www.drupal.org/files/issues/2020-11-05/3144823-6.patch"
+            },
+            "openeuropa/oe_corporate_blocks": {
+                "EWPP-5369": "https://github.com/openeuropa/oe_corporate_blocks/compare/5.x...EWPP-5369.diff"
             }
         },
         "drupal-scaffold": {

--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -1842,6 +1842,18 @@ function oe_theme_preprocess_oe_corporate_blocks_ec_footer(array &$variables) {
   }
   _oe_theme_preprocess_site_specific_footer_links($variables);
   _oe_theme_preprocess_accessibility_link($variables);
+
+  // Move the "Report an IT vulnerability" link to the end of the first
+  // column of the footer, only for standardised branding.
+  if ($variables['ecl_branding'] === 'standardised') {
+    foreach ($variables['corporate_footer']['legal_navigation'] as $index => $link) {
+      if (str_starts_with($link['href'], 'https://commission.europa.eu/legal-notice/vulnerability-disclosure-policy')) {
+        $variables['corporate_footer']['service_navigation'][] = $link;
+        unset($variables['corporate_footer']['legal_navigation'][$index]);
+        break;
+      }
+    }
+  }
 }
 
 /**

--- a/tests/src/Functional/CorporateFooterRenderTest.php
+++ b/tests/src/Functional/CorporateFooterRenderTest.php
@@ -170,6 +170,12 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $section = $assert->elementExists('css', 'footer.ecl-site-footer div.ecl-site-footer__row:nth-child(2) div.ecl-site-footer__column:nth-child(2) div.ecl-site-footer__section:nth-child(1)');
     $items = $data['service_navigation'];
 
+    // The "Report an IT vulnerability" link should be added to this column.
+    $items[] = [
+      'label' => 'Report an IT vulnerability',
+      'href' => 'https://commission.europa.eu/legal-notice/vulnerability-disclosure-policy_en',
+    ];
+
     foreach ($items as $key => $expected) {
       $index = $key + 1;
       $actual = $section->find('css', "ul li:nth-child({$index}) > a");
@@ -178,6 +184,9 @@ class CorporateFooterRenderTest extends BrowserTestBase {
 
     $section = $assert->elementExists('css', 'footer.ecl-site-footer div.ecl-site-footer__row:nth-child(2) div.ecl-site-footer__column:nth-child(3) div.ecl-site-footer__section:nth-child(1)');
     $items = $data['legal_navigation'];
+
+    // The "Report an IT vulnerability" link should be removed from this column.
+    array_shift($items);
 
     foreach ($items as $key => $expected) {
       $index = $key + 1;

--- a/tests/src/Functional/fixtures/ec_footer.yml
+++ b/tests/src/Functional/fixtures/ec_footer.yml
@@ -10,6 +10,9 @@ service_navigation:
     href: 'http://example.com/2-2.html'
 legal_navigation:
   -
+    label: 'Report an IT vulnerability'
+    href: 'https://commission.europa.eu/legal-notice/vulnerability-disclosure-policy_en'
+  -
     label: '3rd section 1st link'
     href: 'http://example.com/3-1.html'
   -


### PR DESCRIPTION
## EWPP-5369

### Description

Move the "Report an IT vulnerability" link to another footer column for standarised branding.

