### PR TITLE
Issue #1605: Fix drupal behaviors attach conflict

### DIFF
--- a/js/ecl_datepicker.js
+++ b/js/ecl_datepicker.js
@@ -5,12 +5,14 @@
 (function (ECL, Drupal) {
   Drupal.behaviors.eclDatepicker = {
     attach: function attach(context, settings) {
-      var elements = document.querySelectorAll('[data-ecl-datepicker-toggle]');
+      var elements = context.querySelectorAll('[data-ecl-datepicker-toggle]');
       for (var i = 0; i < elements.length; i++) {
-        var datepicker = new ECL.Datepicker(elements[i], {
-          format: settings.oe_theme.ecl_datepicker_format
-        });
-        datepicker.init();
+        if(!elements[i].hasAttribute('data-ecl-auto-initialized')) {
+          var datepicker = new ECL.Datepicker(elements[i], {
+            format: settings.oe_theme.ecl_datepicker_format
+          });
+          datepicker.init();
+        }
       }
     }
   };


### PR DESCRIPTION
## Issue #1605 

### Description

Related to https://github.com/openeuropa/oe_theme/issues/1605.
Currently `Drupal.behaviors` usages are not scope enough with some lib init/event.

The first commit is dedicated to `ecl_datepicker ` for now. Could be extended to more js files.
