### PR TITLE
Issue #1617: Twig - Flexibility to extend form select & submit, for extra classes + attributes

### DIFF
--- a/templates/form/input--submit.html.twig
+++ b/templates/form/input--submit.html.twig
@@ -6,13 +6,14 @@
  * @see ./core/themes/stable/templates/form/input.html.twig
  */
 #}
-{% set extraAttributes = [] %}
+{% set extra_attributes = extra_attributes|default([]) %}
 {% for name,value in attributes %}
-  {% set extraAttributes = extraAttributes|merge([{'name': name, 'value': value}]) %}
+  {% set extra_attributes = extra_attributes|merge([{'name': name, 'value': value}]) %}
 {% endfor %}
 
 {% include '@ecl-twig/button' with {
   label: attributes.value,
   variant: variant|default('primary'),
-  extra_attributes: extraAttributes
+  extra_classes: extra_classes|default(''),
+  extra_attributes: extra_attributes
 } %}

--- a/templates/form/select.html.twig
+++ b/templates/form/select.html.twig
@@ -64,6 +64,8 @@
     icon_path: ecl_icon_path,
     id: attributes.id,
     name: attributes.name,
+    extra_classes: extra_classes_input|default(''),
+    extra_attributes: extra_attributes_input|default([]),
     width: width|default('m'),
     options: _options|default([]),
     multiple: _multiple|default(false),


### PR DESCRIPTION
## Issue #1617

### Description

Related to #1617 :: Twig - Flexibility to extend form select & submit, for extra classes + attributes

This a non breaking change proposal, so people would still have per project to extend the necessary and set those.
But on the long term, we should maybe force the `attributes` and `attributes.class` values/content into the final form element by default, so things can work properly by default for new projects without the need to extend those templates.
