### PR TITLE
EWPP-6267: Remove openeuropa/composer-dependent-patches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -120,7 +120,6 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "ec-europa/toolkit-composer-plugin": true,
-            "openeuropa/composer-dependent-patches": true,
             "php-http/discovery": false,
             "phpro/grumphp-shim": true,
             "phpstan/extension-installer": true,


### PR DESCRIPTION
## OPENEUROPA-[Insert ticket number here]

### Description

[Insert description here]

### Change log

- Added:
- Changed:
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

