### PR TITLE
OEL-4458: Fix handling of multiple site owners.

### DIFF
--- a/templates/navigation/oe-corporate-blocks-ec-footer--core.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--core.html.twig
@@ -12,7 +12,10 @@
 #}
 {# Populate the site info section. #}
 {% if site_owner and site_owner|length > 1 %}
-  {% set site_owner_description = 'This site is co-managed by:<br />'|t ~ site_owner|join('<br />') %}
+  {% set site_owner_description %}
+    {{- 'This site is co-managed by:<br />'|t }}
+    {{- site_owner|safe_join('<br />') }}
+  {%- endset %}
 {% else %}
   {% set site_owner_description = site_owner ? 'This site is managed by:<br />@name'|t({'@name': site_owner|first}) %}
 {% endif %}

--- a/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-ec-footer--standardised.html.twig
@@ -12,7 +12,10 @@
 #}
 {# Populate the site info section. #}
 {% if site_owner and site_owner|length > 1 %}
-  {% set site_owner_description = 'This site is co-managed by:<br />'|t ~ site_owner|join('<br />') %}
+  {% set site_owner_description %}
+    {{- 'This site is co-managed by:<br />'|t }}
+    {{- site_owner|safe_join('<br />') }}
+  {%- endset %}
 {% else %}
   {% set site_owner_description = site_owner ? 'This site is managed by:<br />@name'|t({'@name': site_owner|first}) %}
 {% endif %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--core.html.twig
@@ -11,7 +11,10 @@
  */
 #}
 {% if site_owner and site_owner|length > 1 %}
-  {% set site_owner_description = 'This site is co-managed by:<br />'|t ~ site_owner|join('<br />') %}
+  {% set site_owner_description %}
+    {{- 'This site is co-managed by:<br />'|t }}
+    {{- site_owner|safe_join('<br />') }}
+  {%- endset %}
 {% else %}
   {% set site_owner_description = site_owner ? 'This site is managed by:<br />@name'|t({'@name': site_owner|first}) %}
 {% endif %}

--- a/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
+++ b/templates/navigation/oe-corporate-blocks-eu-footer--standardised.html.twig
@@ -79,7 +79,10 @@
   {% endif %}
 
   {% if site_owner and site_owner|length > 1 %}
-    {% set site_owner_description = 'This site is co-managed by:<br />'|t ~ site_owner|join('<br />') %}
+    {% set site_owner_description %}
+      {{- 'This site is co-managed by:<br />'|t }}
+      {{- site_owner|safe_join('<br />') }}
+    {%- endset %}
   {% else %}
     {% set site_owner_description = site_owner ? 'This site is managed by:<br />@name'|t({'@name': site_owner|first}) %}
   {% endif %}

--- a/tests/src/Functional/CorporateFooterRenderTest.php
+++ b/tests/src/Functional/CorporateFooterRenderTest.php
@@ -326,7 +326,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     ], 'EU Site Name');
     $this->drupalGet('<front>');
     $actual = $assert->elementExists('css', 'div.ecl-site-footer__description');
-    $this->assertEquals('This site is co-managed by:<br />Directorate-General for Budget<br />Directorate-General for Economic and Financial Affairs', $actual->getText());
+    $this->assertEquals('This site is co-managed by:<br>Directorate-General for Budget<br>Directorate-General for Economic and Financial Affairs', $actual->getHtml());
 
     // Test European Union footer standardised block rendering.
     $this->branding = 'standardised';
@@ -348,7 +348,7 @@ class CorporateFooterRenderTest extends BrowserTestBase {
     $this->assertEquals('http://web:8080/build/', $actual->getAttribute('href'));
 
     $actual = $assert->elementExists('css', 'div.ecl-site-footer__description');
-    $this->assertEquals('This site is co-managed by:<br />Directorate-General for Budget<br />Directorate-General for Economic and Financial Affairs', $actual->getText());
+    $this->assertEquals('This site is co-managed by:<br>Directorate-General for Budget<br>Directorate-General for Economic and Financial Affairs', $actual->getHtml());
     $actual = $section->find('css', '.ecl-site-footer__section--site-info a.ecl-link.ecl-link--standalone.ecl-site-footer__link');
     $this->assertEquals('Accessibility', $actual->getText());
     $this->assertEquals('/build/', $actual->getAttribute('href'));


### PR DESCRIPTION
There are different issues with the current implementation.

I am only going to point out one here.

Steps to reproduce:
- Add multiple site owners.
- Switch between eu, ec, standardised, core.

In one of them, we will see raw html in the text output.
This is also shown by the test, where we now replace `->getText()` with `->getHtml()` in the assertion.