### PR TITLE
Fix fatal error in oe_theme_preprocess_html() when html_attributes dir is a string

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -814,7 +814,7 @@ function oe_theme_preprocess_html(array &$variables): void {
   }
   // Load specific ECL component library rtl styling for oe_theme and its
   // subthemes for pages with html attribute of rtl.
-  if ($variables['html_attributes']['dir']->value() === 'rtl') {
+  if ((string) $variables['html_attributes']['dir'] === 'rtl') {
     $active_theme = \Drupal::theme()->getActiveTheme();
     if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemeExtensions())) {
       $component_library = theme_get_setting('component_library') ?? 'ec';


### PR DESCRIPTION
## Summary

Fixes #1749

`oe_theme_preprocess_html()` calls `->value()` on `$variables['html_attributes']['dir']`, but Drupal core sets this as a plain string via `Language::getDirection()` (see `core/includes/theme.inc`):

```php
$variables['html_attributes']['dir'] = $language_interface->getDirection();
```

This causes a fatal error on every page load:

```
Error: Call to a member function value() on null in oe_theme_preprocess_html()
```

## Change

Cast to string instead of calling `->value()`:

```php
// Before
if ($variables['html_attributes']['dir']->value() === 'rtl') {

// After
if ((string) $variables['html_attributes']['dir'] === 'rtl') {
```

This is safe for both cases: if `dir` is a plain string (current Drupal core behaviour) or an object with `__toString()`.