### PR TITLE
Fix fatal error in oe_theme_preprocess_html() when html_attributes dir is a string (5.x)

### DIFF
--- a/oe_theme.theme
+++ b/oe_theme.theme
@@ -840,7 +840,7 @@ function oe_theme_preprocess_html(array &$variables): void {
   }
   // Load specific ECL component library rtl styling for oe_theme and its
   // subthemes for pages with html attribute of rtl.
-  if ($variables['html_attributes']['dir']->value() === 'rtl') {
+  if ((string) $variables['html_attributes']['dir'] === 'rtl') {
     $active_theme = \Drupal::theme()->getActiveTheme();
     if ($active_theme->getName() === 'oe_theme' || array_key_exists('oe_theme', $active_theme->getBaseThemeExtensions())) {
       $component_library = _oe_theme_helper_get_theme_setting('component_library') ?? 'ec';


### PR DESCRIPTION
## Summary

Backport of #1750 to the `5.x` branch.

Fixes #1749

`oe_theme_preprocess_html()` calls `->value()` on `$variables['html_attributes']['dir']`, but Drupal core sets this as a plain string via `Language::getDirection()`:

```php
$variables['html_attributes']['dir'] = $language_interface->getDirection();
```

This causes a fatal error on every page load:

```
Error: Call to a member function value() on null in oe_theme_preprocess_html()
```

## Change

Cast to string instead of calling `->value()`:

```php
// Before
if ($variables['html_attributes']['dir']->value() === 'rtl') {

// After
if ((string) $variables['html_attributes']['dir'] === 'rtl') {
```

Safe for both cases: plain string (current Drupal core behaviour) or an object with `__toString()`.